### PR TITLE
Support Singles when not part of an Album

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -35,7 +35,9 @@ function retrieveReleaseInfo() {
     // Grab release event information
     var releasedate = bandcampAlbumData.current.release_date;
 
-	 var parent_album = bandcampEmbedData.album_title;
+	 if(bandcampEmbedData.album_title) {
+		 release.parent_album = bandcampEmbedData.album_title;
+    }
 
     if (typeof releasedate != "undefined" && releasedate != "") {
         release.year = $.format.date(releasedate, "yyyy");
@@ -52,7 +54,7 @@ function retrieveReleaseInfo() {
 
 	 // map Bandcamp single tracks to singles
 	 if(release.type == "track")
-	 { release.type = "Single"; }
+	 { release.type = "single"; }
 
 	// Tracks
     var disc = new Object();
@@ -76,7 +78,8 @@ function retrieveReleaseInfo() {
 // Insert links in page
 function insertLink(release) {
 
-	if(typeof parent_album == "undefined") {
+	if(release.type == "single" && typeof release.parent_album != "undefined") {
+		mylog("This is part of an album, not continuing.");
 		return false;
 	}
 


### PR DESCRIPTION
These changes allow singles that aren't attached to an album to be imported, setting the 'single' release type as necessary (which has to be modified from 'track'.

Examples:
- [Chipwrecked](http://rainbowdragoneyes.bandcamp.com/track/chipwrecked) should show a button, and import as a Single (new behavior).
- [111111](http://rainbowdragoneyes.bandcamp.com/album/111111) should show a button, and import as an Album (normal behavior).
- [Seize My Day](http://rainbowdragoneyes.bandcamp.com/track/seize-my-day) should NOT show a button (expected behavior).
