### PR TITLE
Updated URL of jquery-dateFormat (added 'src' path component)

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -5,7 +5,7 @@
 // @include        http://*.bandcamp.com/album/*
 // @include        http://*.bandcamp.com/track/*
 // @require        https://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.js
-// @require        https://raw.github.com/phstc/jquery-dateFormat/master/jquery.dateFormat-1.0.js
+// @require        https://raw.github.com/phstc/jquery-dateFormat/master/src/jquery.dateFormat.js
 // @require        https://raw.github.com/murdos/musicbrainz-userscripts/master/lib/import_functions.js
 // ==/UserScript==
 


### PR DESCRIPTION
Updated URL of jquery-dateFormat (added 'src' path component). Old URL now gives 404 so script cannot be installed.
