### PR TITLE
[bandcamp] Fix URL adding "name your price" downloads.

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -84,8 +84,7 @@ function retrieveReleaseInfo() {
             bandcampAlbumData.current.minimum_price == 0.0) {
                 release.urls.push( { 'url': window.location.href, 'link_type': 75 } );
         }
-        if (bandcampAlbumData.current.minimum_price_nonzero !== null &&
-            bandcampAlbumData.current.minimum_price > 0.0) {
+        if (bandcampAlbumData.current.minimum_price_nonzero !== null) {
             release.urls.push( { 'url': window.location.href, 'link_type': 74 } );
         }
     }


### PR DESCRIPTION
The logic checked for minimum_price > 0 and == 0 both, while they obviously cannot both be true.
