### PR TITLE
Beatport Importer Userscript v1

### DIFF
--- a/beatport_importer.user.js
+++ b/beatport_importer.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name           MusicBrainz: Import from Beatport
-// @version        2014.09.21.0
+// @version        2014.09.26.0
 // @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_importer.user.js
 // @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_importer.user.js
 // @include        http*://www.beatport.com/release/*


### PR DESCRIPTION
This script currently supports importing;
- Release Title
- Release Label
- Release Catalog Number (if available)
- Release Date
- Tracklist

Note that Beatport's catalog information doesn't have join phrases, their web site merely adds a comma. I've opted not to include a join phrase for the moment.
Tested with http://www.beatport.com/release/stay-the-night/1187110 and http://www.beatport.com/release/dare-you-the-remixes-part-1-remixes-by-tiesto-vs-twoloud-and-cash-cash/1238454

/cc @murdos
Closes #18
