### PR TITLE
Beatport Pro Importer v1

### DIFF
--- a/beatport_pro_importer.user.js
+++ b/beatport_pro_importer.user.js
@@ -33,6 +33,8 @@ function retrieveReleaseInfo() {
   release.urls.push( { 'url': window.location.href } );
   release.id = $( "a[data-release]" ).attr('data-release');
 
+  release.title = $( "h3.interior-type:contains('Release')" ).next().text().trim();
+
   var releaseDate = $( ".category:contains('Release Date')" ).next().text().split("-");
   release.year = releaseDate[0];
   release.month = releaseDate[1];


### PR DESCRIPTION
Beatport is working on a new version of their site, currently called Beatport Pro and available at https://pro.beatport.com . The JSON data is still the same, generated from their same API infrastructure, but the way to actually get at the JSON data changed significantly. This userscript runs solely on pro.beatport.com URLs for now, but can be promoted to the general Beatport importer as soon as it becomes the default interface for everyone.

![screen shot 2014-10-03 at 17 51 10](https://cloud.githubusercontent.com/assets/1882/4513960/6b7ddcc4-4b58-11e4-83a4-8db22096fd14.png)
