### PR TITLE
Bandcamp: use publish date if album release date is before Bandcamp launch

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name           Import Bandcamp releases into MB
-// @version        2014.10.08.1
+// @version        2014.10.18.1
 // @namespace      http://userscripts.org/users/22504
 // @downloadURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL      https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js


### PR DESCRIPTION
Date is parsed using native js Date(), not sure why an external lib was used before.

Bandcamp was launched on 2008-09, so digital releases can hardly be released before this date, release date is often set to the CD/vinyl release date on Bandcamp.
Release date is still used in priority, since nowadays digital releases often occur at the same time as the CD/vinyl, and Bandcamp isn't the only source for digital releases (ie. iTunes/Amazon may have a digital release available before Bandcamp has it).

I was pondering about using only the publish date, but it can be wrong too (ie. when few tracks are pre-released). Not sure what is the best.

See http://musicbrainz.org/edit/29612074
