### PR TITLE
Fix "Unknown field: as_auto_editor" error when importing

### DIFF
--- a/lib/import_functions.js
+++ b/lib/import_functions.js
@@ -174,9 +174,6 @@ var MBReleaseImportHelper = (function() {
         // Add Edit note parameter
         appendParameter(parameters, 'edit_note', edit_note);
 
-        // Set auto-editor flag, http://tickets.musicbrainz.org/browse/MBS-4315
-        appendParameter(parameters, 'as_auto_editor', "1");
-
         return parameters;
     }
 


### PR DESCRIPTION
Since last MB server update (http://blog.musicbrainz.org/2014/11/03/server-update-2014-11-03/), importing causes the server to emit this error:

The data you’ve seeded contained the following errors:

```
Unknown field: as_auto_editor
```

This field was removed, replaced by 'make_votable' which is always unchecked by default.
So basically those lines aren't needed anymore.
