### PR TITLE
fix #31: handle discogs tracks in case of sub-tracks

### DIFF
--- a/discogs_importer.user.js
+++ b/discogs_importer.user.js
@@ -371,6 +371,10 @@ function parseDiscogsRelease(data) {
         // Track position and release number
         var trackPosition = discogsTrack.position;
 
+        if (trackPosition == "" && discogsTrack.sub_tracks) {
+            trackPosition = discogsTrack.sub_tracks[0].position;
+        }
+
         // Skip special tracks
         if (trackPosition.toLowerCase().match("^(video|mp3)")) {
             trackPosition = "";


### PR DESCRIPTION
in case of sub-tracks (at least for http://api.discogs.com/releases/5880212 ),
json field "position" is "" so previous code ignored the track.

The solution here is to use first sub-track position which is good enough to detect change of CD numbers.