### PR TITLE
Display the link to the current album when not on an bandcamp /album/…

### DIFF
--- a/bandcamp_importer_helper.user.js
+++ b/bandcamp_importer_helper.user.js
@@ -1,0 +1,27 @@
+// ==UserScript==
+// @name        Bandcamp Importer Album Link Helper
+// @version     2015.05.19.0
+// @namespace      http://userscripts.org/users/22504
+// @downloadURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer_helper.user.js
+// @updateURL      https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer_helper.user.js
+// @include     http*://*.bandcamp.com/
+// @include     http*://*.bandcamp.com/releases
+// @exclude     http*://*.bandcamp.com/*/*
+// @grant       none
+// @require     https://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.js
+// @require     https://raw.github.com/murdos/musicbrainz-userscripts/master/lib/logger.js
+// ==/UserScript==
+
+
+$(document).ready(function(){
+
+  // Display a link to the correct album bandcamp url (ie. main page or releases page)
+  // search for the rss feed link and use it to build the current album url
+  rssurl = $("#rssFeedAlbum").attr('href');
+  if (typeof rssurl !== "undefined" && rssurl.indexOf('/feed/album/') !== -1) {
+    albumurl = rssurl.replace('/feed/', '/');
+    innerHTML = '<div id="bci_helper" style="padding-top: 5px;"><a href="' + albumurl + '" title="Load album page and display Import to MB button">Album page (MB import)</a></div>';
+    $('#name-section').append(innerHTML);
+  }
+});
+


### PR DESCRIPTION
… page

This is an experimental helper, it will just display the link to the correct /album/ page for the Bandcamp importer to work when user loaded a main page with only one album or a /releases page with one album.

In those cases, a link to album rss feed is displayed, the script uses it, removing /feed/ in it to obtain the desired url.