### PR TITLE
Bandcamp import: attempt to detect label when release page is a sub-p…

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name           Import Bandcamp releases into MB
-// @version        2015.05.16.0
+// @version        2015.05.20.0
 // @namespace      http://userscripts.org/users/22504
 // @downloadURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL      https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
@@ -140,6 +140,16 @@ function retrieveReleaseInfo() {
             'url': $("div#license a.cc-icons").attr("href"),
             'link_type': LINK_LICENSE
         });
+    }
+
+    // Check if album has a back link to a label
+    label = $("a.back-to-label-link span.back-to-label-name").text();
+    if (label != "") {
+      release.labels.push({
+        'name': label,
+        'mbid': '',
+        'catno': 'none'
+      });
     }
 
     LOGGER.info("Parsed release: ", release);


### PR DESCRIPTION
…age of one

When a label has its own bandcamp page, most releases have a back link to the root page for the label.

Ie. https://baroness.bandcamp.com/album/yellow-green has a link on the top left to Relapse Records artists page (https://relapserecords.bandcamp.com/artists)

The code detects if such link exists and use the label's name to prefill the Add Release form.
Of course, sometimes it will be wrong, because the so-called label on Bandcamp isn't a real label, the user should be able to sort it out.