### PR TITLE
Bandcamp importer: add links to matching MB artist and releases

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -8,8 +8,9 @@
 // @include        http*://*.bandcamp.com/album/*
 // @include        http*://*.bandcamp.com/track/*
 // @require        https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js
-// @require        https://raw.github.com/murdos/musicbrainz-userscripts/master/lib/import_functions.js
-// @require        https://raw.github.com/murdos/musicbrainz-userscripts/master/lib/logger.js
+// @require        lib/import_functions.js
+// @require        lib/logger.js
+// @require        lib/mblinks.js
 // @grant          None
 // ==/UserScript==
 
@@ -200,107 +201,6 @@ var BandcampImport = {
     }
     return false;
   }
-};
-
-var MBLinks = function (cachekey, expiration) {
-  this.supports_local_storage = function () {
-    try {
-      return !!localStorage.getItem;
-    } catch (e) {
-      return false;
-    }
-  }();
-
-  this.ajax_requests = [];
-  this.cache = {};
-  this.expirationMinutes = parseInt(expiration);
-  this.cache_key = cachekey;
-
-  this.initAjaxEngine = function () {
-    var ajax_requests = this.ajax_requests;
-    setInterval(function () {
-      if (ajax_requests.length > 0) {
-        var request = ajax_requests.shift();
-        if (typeof request === "function") {
-          request();
-        }
-      }
-    }, 1000);
-  };
-
-  this.initCache = function () {
-    if (!this.supports_local_storage) return;
-    // Check if we already added links for this content
-    var cache_string = localStorage.getItem(this.cache_key);
-    if (!cache_string) {
-      cache_string = "{}";
-    }
-    this.cache = JSON.parse(cache_string);
-  };
-
-  this.saveCache = function () {
-    if (!this.supports_local_storage) return;
-    try {
-      localStorage.setItem(this.cache_key, JSON.stringify(this.cache));
-    } catch (e) {
-      alert(e);
-    }
-  },
-
-  this.createMusicBrainzLink = function (mb_url, mb_type) {
-    return '<a href="' + mb_url + '" title="Link to MB ' + mb_type +
-      '"><img src="//musicbrainz.org/static/images/entity/' + mb_type + '.png" /></a> ';
-  };
-
-  this.searchAndDisplayMbLink = function (url, mb_type, insert_func) {
-    var mblinks = this;
-
-    if (mb_type != 'artist' && mb_type != 'release' && mb_type != 'label' && mb_type != 'release-group') {
-      return;
-    }
-
-    if (mblinks.cache[url]
-        && mblinks.expirationMinutes > 0
-        && new Date().getTime() < mblinks.cache[url].timestamp) {
-      $.each(mblinks.cache[url].urls, function (idx, mb_url) {
-        insert_func(mblinks.createMusicBrainzLink(mb_url, mb_type));
-      });
-    } else {
-      mblinks.ajax_requests.push($.proxy(function () {
-        var context = this;
-        $.getJSON('//musicbrainz.org/ws/2/url?resource=' + context.url + '&inc=' + context.mb_type +
-          '-rels',
-          function (data) {
-            if ('relations' in data) {
-              var expires = new Date().getTime() + (mblinks.expirationMinutes * 60 * 1000);
-              mblinks.cache[context.url] = {
-                timestamp: expires,
-                urls: []
-              };
-              $.each(data['relations'], function (idx, relation) {
-                if (context.mb_type.replace('-', '_') in relation) {
-                  var mb_url = '//musicbrainz.org/' + context.mb_type + '/' + relation[context.mb_type.replace('-', '_')]['id'];
-                  if ($.inArray(mb_url, mblinks.cache[context.url].urls) == -1) { // prevent dupes
-                    mblinks.cache[context.url].urls.push(mb_url);
-                    mblinks.saveCache();
-                    context.insert_func(mblinks.createMusicBrainzLink(mb_url, mb_type));
-                  }
-                }
-              });
-            }
-          });
-      }, {
-        'url': url,
-        'insert_func': insert_func,
-        'mb_type': mb_type
-      }));
-    }
-  };
-
-  this.initCache();
-  this.initAjaxEngine();
-
-  return this;
 };
 
 $(document).ready(function () {

--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -28,6 +28,7 @@ var MBLinks = function (cachekey, expiration) {
   this.cache = {};
   this.expirationMinutes = parseInt(expiration);
   this.cache_key = cachekey;
+  this.mb_server = '//musicbrainz.org';
 
   this.initAjaxEngine = function () {
     var ajax_requests = this.ajax_requests;
@@ -62,7 +63,7 @@ var MBLinks = function (cachekey, expiration) {
 
   this.createMusicBrainzLink = function (mb_url, mb_type) {
     return '<a href="' + mb_url + '" title="Link to MB ' + mb_type +
-      '"><img src="//musicbrainz.org/static/images/entity/' + mb_type + '.png" /></a> ';
+      '"><img src="' + this.mb_server + '/static/images/entity/' + mb_type + '.png" /></a> ';
   };
 
   // Search for ressource 'url' on MB, for relation of type 'mb_type' (artist, release, label, release-group)
@@ -84,7 +85,7 @@ var MBLinks = function (cachekey, expiration) {
     } else {
       mblinks.ajax_requests.push($.proxy(function () {
         var context = this;
-        $.getJSON('//musicbrainz.org/ws/2/url?resource=' + encodeURIComponent(context.url)
+        $.getJSON(mblinks.mb_server + '/ws/2/url?resource=' + encodeURIComponent(context.url)
                   + '&inc=' + context.mb_type + '-rels',
           function (data) {
             if ('relations' in data) {
@@ -96,7 +97,7 @@ var MBLinks = function (cachekey, expiration) {
               var _type = context.mb_type.replace('-', '_');
               $.each(data['relations'], function (idx, relation) {
                 if (_type in relation) {
-                  var mb_url = '//musicbrainz.org/' + context.mb_type + '/' + relation[_type]['id'];
+                  var mb_url = mblinks.mb_server + '/' + context.mb_type + '/' + relation[_type]['id'];
                   if ($.inArray(mb_url, mblinks.cache[context.url].urls) == -1) { // prevent dupes
                     mblinks.cache[context.url].urls.push(mb_url);
                     mblinks.saveCache();

--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -84,8 +84,8 @@ var MBLinks = function (cachekey, expiration) {
     } else {
       mblinks.ajax_requests.push($.proxy(function () {
         var context = this;
-        $.getJSON('//musicbrainz.org/ws/2/url?resource=' + context.url + '&inc=' + context.mb_type +
-          '-rels',
+        $.getJSON('//musicbrainz.org/ws/2/url?resource=' + encodeURIComponent(context.url)
+                  + '&inc=' + context.mb_type + '-rels',
           function (data) {
             if ('relations' in data) {
               var expires = new Date().getTime() + (mblinks.expirationMinutes * 60 * 1000);

--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -93,9 +93,10 @@ var MBLinks = function (cachekey, expiration) {
                 timestamp: expires,
                 urls: []
               };
+              var _type = context.mb_type.replace('-', '_');
               $.each(data['relations'], function (idx, relation) {
-                if (context.mb_type.replace('-', '_') in relation) {
-                  var mb_url = '//musicbrainz.org/' + context.mb_type + '/' + relation[context.mb_type.replace('-', '_')]['id'];
+                if (_type in relation) {
+                  var mb_url = '//musicbrainz.org/' + context.mb_type + '/' + relation[_type]['id'];
                   if ($.inArray(mb_url, mblinks.cache[context.url].urls) == -1) { // prevent dupes
                     mblinks.cache[context.url].urls.push(mb_url);
                     mblinks.saveCache();

--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -92,11 +92,11 @@ var MBLinks = function (cachekey, expiration) {
                   var mb_url = mblinks.mb_server + '/' + context.mb_type + '/' + relation[_type]['id'];
                   if ($.inArray(mb_url, mblinks.cache[context.url].urls) == -1) { // prevent dupes
                     mblinks.cache[context.url].urls.push(mb_url);
-                    mblinks.saveCache();
                     context.insert_func(mblinks.createMusicBrainzLink(mb_url, mb_type));
                   }
                 }
               });
+              mblinks.saveCache();
             }
           });
       }, {

--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -45,11 +45,7 @@ var MBLinks = function (cachekey, expiration) {
   this.initCache = function () {
     if (!this.supports_local_storage) return;
     // Check if we already added links for this content
-    var cache_string = localStorage.getItem(this.cache_key);
-    if (!cache_string) {
-      cache_string = "{}";
-    }
-    this.cache = JSON.parse(cache_string);
+    this.cache = JSON.parse(localStorage.getItem(this.cache_key) || '{}');
   };
 
   this.saveCache = function () {

--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -62,15 +62,11 @@ var MBLinks = function (cachekey, expiration) {
       '"><img src="' + this.mb_server + '/static/images/entity/' + mb_type + '.png" /></a> ';
   };
 
-  // Search for ressource 'url' on MB, for relation of type 'mb_type' (artist, release, label, release-group)
+  // Search for ressource 'url' on MB, for relation of type 'mb_type' (artist, release, label, release-group, ...)
   // and call 'insert_func' function with matching MB links (a tag built in createMusicBrainzLink) for each
   // entry found
   this.searchAndDisplayMbLink = function (url, mb_type, insert_func) {
     var mblinks = this;
-
-    if (mb_type != 'artist' && mb_type != 'release' && mb_type != 'label' && mb_type != 'release-group') {
-      return;
-    }
 
     if (mblinks.cache[url]
         && mblinks.expirationMinutes > 0

--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -1,0 +1,120 @@
+// Class MBLinks : query MusicBrainz for urls and display links for matching urls
+// The main method is searchAndDisplayMbLink()
+
+// Example:
+// $(document).ready(function () {
+//
+//  var mblinks = new MBLinks('EXAMPLE_MBLINKS_CACHE', 7*24*60); // force refresh of cached links once a week
+//
+//  var artist_link = 'http://' + window.location.href.match( /^https?:\/\/(.*)\/album\/.+$/i)[1];
+//  mblinks.searchAndDisplayMbLink(artist_link, 'artist', function (link) { $('div#there').before(link); } );
+//
+//  var album_link = 'http://' + window.location.href.match( /^https?:\/\/(.*\/album\/.+)$/i)[1];
+//  mblinks.searchAndDisplayMbLink(album_link, 'release', function (link) { $('div#there').after(link); } );
+// }
+
+// cachekey = textual key used to store cached data in local storage
+// expiration = time in minutes before an entry is refreshed, value <= 0 disables cache reads
+var MBLinks = function (cachekey, expiration) {
+  this.supports_local_storage = function () {
+    try {
+      return !!localStorage.getItem;
+    } catch (e) {
+      return false;
+    }
+  }();
+
+  this.ajax_requests = [];
+  this.cache = {};
+  this.expirationMinutes = parseInt(expiration);
+  this.cache_key = cachekey;
+
+  this.initAjaxEngine = function () {
+    var ajax_requests = this.ajax_requests;
+    setInterval(function () {
+      if (ajax_requests.length > 0) {
+        var request = ajax_requests.shift();
+        if (typeof request === "function") {
+          request();
+        }
+      }
+    }, 1000);
+  };
+
+  this.initCache = function () {
+    if (!this.supports_local_storage) return;
+    // Check if we already added links for this content
+    var cache_string = localStorage.getItem(this.cache_key);
+    if (!cache_string) {
+      cache_string = "{}";
+    }
+    this.cache = JSON.parse(cache_string);
+  };
+
+  this.saveCache = function () {
+    if (!this.supports_local_storage) return;
+    try {
+      localStorage.setItem(this.cache_key, JSON.stringify(this.cache));
+    } catch (e) {
+      alert(e);
+    }
+  },
+
+  this.createMusicBrainzLink = function (mb_url, mb_type) {
+    return '<a href="' + mb_url + '" title="Link to MB ' + mb_type +
+      '"><img src="//musicbrainz.org/static/images/entity/' + mb_type + '.png" /></a> ';
+  };
+
+  // Search for ressource 'url' on MB, for relation of type 'mb_type' (artist, release, label, release-group)
+  // and call 'insert_func' function with matching MB links (a tag built in createMusicBrainzLink) for each
+  // entry found
+  this.searchAndDisplayMbLink = function (url, mb_type, insert_func) {
+    var mblinks = this;
+
+    if (mb_type != 'artist' && mb_type != 'release' && mb_type != 'label' && mb_type != 'release-group') {
+      return;
+    }
+
+    if (mblinks.cache[url]
+        && mblinks.expirationMinutes > 0
+        && new Date().getTime() < mblinks.cache[url].timestamp) {
+      $.each(mblinks.cache[url].urls, function (idx, mb_url) {
+        insert_func(mblinks.createMusicBrainzLink(mb_url, mb_type));
+      });
+    } else {
+      mblinks.ajax_requests.push($.proxy(function () {
+        var context = this;
+        $.getJSON('//musicbrainz.org/ws/2/url?resource=' + context.url + '&inc=' + context.mb_type +
+          '-rels',
+          function (data) {
+            if ('relations' in data) {
+              var expires = new Date().getTime() + (mblinks.expirationMinutes * 60 * 1000);
+              mblinks.cache[context.url] = {
+                timestamp: expires,
+                urls: []
+              };
+              $.each(data['relations'], function (idx, relation) {
+                if (context.mb_type.replace('-', '_') in relation) {
+                  var mb_url = '//musicbrainz.org/' + context.mb_type + '/' + relation[context.mb_type.replace('-', '_')]['id'];
+                  if ($.inArray(mb_url, mblinks.cache[context.url].urls) == -1) { // prevent dupes
+                    mblinks.cache[context.url].urls.push(mb_url);
+                    mblinks.saveCache();
+                    context.insert_func(mblinks.createMusicBrainzLink(mb_url, mb_type));
+                  }
+                }
+              });
+            }
+          });
+      }, {
+        'url': url,
+        'insert_func': insert_func,
+        'mb_type': mb_type
+      }));
+    }
+  };
+
+  this.initCache();
+  this.initAjaxEngine();
+
+  return this;
+};


### PR DESCRIPTION
Based on the discogs importer code, but with few improvements:
- localStorage entries can expire (set to 1 week)
- code has its own namespace, and is more generic (it will move to a lib later)
- prevent jquery libs conflicts (GM vs website), jquery upgraded to 2.1.4

Test: https://redfang.bandcamp.com/album/whales-and-leeches-deluxe-version
![capture du 2015-06-04 15 32 30](https://cloud.githubusercontent.com/assets/151042/7985172/17a79f90-0acf-11e5-9a16-9de5ebcc3c78.png)
