### PR TITLE
BeatPort Pro: make it work again

### DIFF
--- a/beatport_pro_importer.user.js
+++ b/beatport_pro_importer.user.js
@@ -66,6 +66,7 @@ function retrieveReleaseInfo(release_url) {
   var the_tracks = unsafeWindow.Playables.tracks;
   var seen_tracks = {}; // to shoot duplicates ...
   var release_artists = [];
+  var total_duration = 0;
   $.each(the_tracks,
     function (idx, track) {
       if (track.release.id != release_id) {
@@ -93,6 +94,7 @@ function retrieveReleaseInfo(release_url) {
         'title': title,
         'duration': track.duration.minutes
       });
+      total_duration += track.duration.milliseconds;
     }
   );
 
@@ -109,6 +111,7 @@ function retrieveReleaseInfo(release_url) {
     'format': release.format
   } );
 
+  release.type = MBReleaseImportHelper.guessReleaseType(release.title, tracks.length, total_duration/1000);
   LOGGER.info("Parsed release: ", release);
   return release;
 }

--- a/beatport_pro_importer.user.js
+++ b/beatport_pro_importer.user.js
@@ -74,9 +74,7 @@ function retrieveReleaseInfo(release_url) {
       var artists = [];
       $.each(track.artists,
         function (idx2,  artist) {
-          artists.push({
-            'artist_name': artist.name
-          });
+          artists.push(artist.name);
           release_artists.push(artist.name);
         }
       );
@@ -86,7 +84,7 @@ function retrieveReleaseInfo(release_url) {
         title += ' (' + track.mix + ')';
       }
       tracks.push({
-        'artist_credit': artists,
+        'artist_credit': MBReleaseImportHelper.makeArtistCredits(artists),
         'title': title,
         'duration': track.duration.minutes
       });
@@ -99,22 +97,7 @@ function retrieveReleaseInfo(release_url) {
     }
   });
 
-  var artists = unique_artists.map(function(item) { return {artist_name: item}; });
-  if (artists.length > 2) {
-    var last = artists.pop();
-    last.joinphrase = '';
-    var prev = artists.pop();
-    prev.joinphrase = ' & ';
-    for (var i = 0; i < artists.length; i++) {
-      artists[i].joinphrase = ', ';
-    }
-    artists.push(prev);
-    artists.push(last);
-  } else if (artists.length == 2) {
-    artists[0].joinphrase = ' & ';
-  }
-
-  release.artist_credit = artists;
+  release.artist_credit = MBReleaseImportHelper.makeArtistCredits(unique_artists);
   release.discs = [];
   release.discs.push( {
     'tracks': tracks,

--- a/beatport_pro_importer.user.js
+++ b/beatport_pro_importer.user.js
@@ -19,20 +19,18 @@ this.$ = this.jQuery = jQuery.noConflict(true);
 if (!unsafeWindow) unsafeWindow = window;
 
 $(document).ready(function(){
-  var release = retrieveReleaseInfo();
-  insertLink(release);
+  var release_url = window.location.href.replace('/\?.*$/', '').replace(/#.*$/, '');
+  var release = retrieveReleaseInfo(release_url);
+  insertLink(release, release_url);
 });
 
-
-function retrieveReleaseInfo() {
+function retrieveReleaseInfo(release_url) {
   var release = {};
 
   // Release information global to all Beatport releases
   release.packaging = 'None';
   release.country = "XW";
   release.status = 'official';
-  release.urls = [];
-  release.urls.push( { 'url': window.location.href } );
   release.id = $( "span.playable-play-all[data-release]" ).attr('data-release');
 
   release.title = $( "h3.interior-type:contains('Release')" ).next().text().trim();
@@ -41,6 +39,14 @@ function retrieveReleaseInfo() {
   release.year = releaseDate[0];
   release.month = releaseDate[1];
   release.day = releaseDate[2];
+
+  // URLs
+  release.urls = [];
+
+  release.urls.push({
+    'url': release_url,
+    'link_type': MBReleaseImportHelper.URL_TYPES.purchase_for_download
+  });
 
   release.labels = [];
   release.labels.push(
@@ -120,8 +126,8 @@ function retrieveReleaseInfo() {
 }
 
 // Insert button into page under label information
-function insertLink(release) {
-    var edit_note = 'Imported from ' + window.location.href;
+function insertLink(release, release_url) {
+    var edit_note = 'Imported from ' + release_url;
     var parameters = MBReleaseImportHelper.buildFormParameters(release, edit_note);
 
     var innerHTML = MBReleaseImportHelper.buildFormHTML(parameters);

--- a/beatport_pro_importer.user.js
+++ b/beatport_pro_importer.user.js
@@ -1,6 +1,7 @@
 // ==UserScript==
 // @name           Import Beatport Pro releases to MusicBrainz
 // @author         VxJasonxV
+// @namespace      https://github.com/murdos/musicbrainz-userscripts/
 // @description    One-click importing of releases from pro.beatport.com/release pages into MusicBrainz
 // @version        2015.06.10.1
 // @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_pro_importer.user.js

--- a/beatport_pro_importer.user.js
+++ b/beatport_pro_importer.user.js
@@ -31,7 +31,6 @@ function retrieveReleaseInfo(release_url) {
   release.packaging = 'None';
   release.country = "XW";
   release.status = 'official';
-  release.id = $( "span.playable-play-all[data-release]" ).attr('data-release');
 
   release.title = $( "h3.interior-type:contains('Release')" ).next().text().trim();
 
@@ -39,6 +38,7 @@ function retrieveReleaseInfo(release_url) {
   release.year = releaseDate[0];
   release.month = releaseDate[1];
   release.day = releaseDate[2];
+  var release_id = $( "span.playable-play-all[data-release]" ).attr('data-release');
 
   // URLs
   release.urls = [];
@@ -63,7 +63,7 @@ function retrieveReleaseInfo(release_url) {
   var release_artists = [];
   $.each(the_tracks,
     function (idx, track) {
-      if (track.release.id != release.id) {
+      if (track.release.id != release_id) {
         return;
       }
       if (seen_tracks[track.id]) {

--- a/beatport_pro_importer.user.js
+++ b/beatport_pro_importer.user.js
@@ -2,7 +2,6 @@
 // @name           Import Beatport Pro releases to MusicBrainz
 // @author         VxJasonxV
 // @description    One-click importing of releases from pro.beatport.com/release pages into MusicBrainz
-// @sourceURL      https://github.com/VxJasonxV/musicbrainz-userscripts/blob/master/beatport_pro_importer.user.js
 // @version        2015.06.10.1
 // @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_pro_importer.user.js
 // @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_pro_importer.user.js

--- a/beatport_pro_importer.user.js
+++ b/beatport_pro_importer.user.js
@@ -105,6 +105,9 @@ function retrieveReleaseInfo(release_url) {
     }
   });
 
+  if (unique_artists.length > 4) {
+    unique_artists = [ 'Various Artists' ];
+  }
   release.artist_credit = MBReleaseImportHelper.makeArtistCredits(unique_artists);
   release.discs.push( {
     'tracks': tracks,

--- a/beatport_pro_importer.user.js
+++ b/beatport_pro_importer.user.js
@@ -25,30 +25,35 @@ $(document).ready(function(){
 });
 
 function retrieveReleaseInfo(release_url) {
-  var release = {};
+  var releaseDate = $( ".category:contains('Release Date')" ).next().text().split("-");
 
   // Release information global to all Beatport releases
-  release.packaging = 'None';
-  release.country = "XW";
-  release.status = 'official';
+  var release = {
+    artist_credit: [],
+    title: $( "h3.interior-type:contains('Release')" ).next().text().trim(),
+    year: releaseDate[0],
+    month: releaseDate[1],
+    day: releaseDate[2],
+    format: 'Digital Media',
+    packaging: 'None',
+    country: 'XW',
+    status: 'official',
+    language: 'eng',
+    script: 'Latn',
+    type: '',
+    urls: [],
+    labels: [],
+    discs: [],
+  };
 
-  release.title = $( "h3.interior-type:contains('Release')" ).next().text().trim();
-
-  var releaseDate = $( ".category:contains('Release Date')" ).next().text().split("-");
-  release.year = releaseDate[0];
-  release.month = releaseDate[1];
-  release.day = releaseDate[2];
   var release_id = $( "span.playable-play-all[data-release]" ).attr('data-release');
 
   // URLs
-  release.urls = [];
-
   release.urls.push({
     'url': release_url,
     'link_type': MBReleaseImportHelper.URL_TYPES.purchase_for_download
   });
 
-  release.labels = [];
   release.labels.push(
     {
       name: $( ".category:contains('Labels')" ).next().text().trim(),
@@ -90,6 +95,7 @@ function retrieveReleaseInfo(release_url) {
       });
     }
   );
+
   var unique_artists = [];
   $.each(release_artists, function(i, el){
     if ($.inArray(el, unique_artists) === -1) {
@@ -98,10 +104,9 @@ function retrieveReleaseInfo(release_url) {
   });
 
   release.artist_credit = MBReleaseImportHelper.makeArtistCredits(unique_artists);
-  release.discs = [];
   release.discs.push( {
     'tracks': tracks,
-    'format': "Digital Media"
+    'format': release.format
   } );
 
   LOGGER.info("Parsed release: ", release);

--- a/lib/import_functions.js
+++ b/lib/import_functions.js
@@ -201,6 +201,21 @@ var MBReleaseImportHelper = (function() {
       return artists;
     }
 
+    // Try to guess release type using number of tracks, title and total duration (in secs)
+    function fnGuessReleaseType(title, num_tracks, duration) {
+      if (num_tracks < 1 || duration < 60) return '';
+      var has_single = !!title.match(/\bsingle\b/i);
+      var has_EP = !!title.match(/\bEP\b/i);
+      if (has_single && has_EP) {
+        has_single = false;
+        has_EP = false;
+      }
+      if (((has_single && num_tracks <= 4) || num_tracks <= 2) && duration <= 11*60) return 'single';
+      if ((has_EP || num_tracks <= 6) && duration <= 30*60) return 'EP';
+      if (duration > 30*60 && num_tracks > 6) return 'album';
+      return '';
+    }
+
     // --------------------------------------- privates ----------------------------------------- //
 
     function appendParameter(parameters, paramName, paramValue) {
@@ -233,6 +248,7 @@ var MBReleaseImportHelper = (function() {
        buildFormHTML: fnBuildFormHTML,
        buildFormParameters: fnBuildFormParameters,
        makeArtistCredits: fnArtistCredits,
+       guessReleaseType: fnGuessReleaseType,
        URL_TYPES: url_types
     };
 })();

--- a/lib/import_functions.js
+++ b/lib/import_functions.js
@@ -182,6 +182,25 @@ var MBReleaseImportHelper = (function() {
         return parameters;
     }
 
+    // Convert a list of artists to a list of artist credits with joinphrases
+    function fnArtistCredits(artists_list) {
+      var artists = artists_list.map(function(item) { return {artist_name: item}; });
+      if (artists.length > 2) {
+        var last = artists.pop();
+        last.joinphrase = '';
+        var prev = artists.pop();
+        prev.joinphrase = ' & ';
+        for (var i = 0; i < artists.length; i++) {
+          artists[i].joinphrase = ', ';
+        }
+        artists.push(prev);
+        artists.push(last);
+      } else if (artists.length == 2) {
+        artists[0].joinphrase = ' & ';
+      }
+      return artists;
+    }
+
     // --------------------------------------- privates ----------------------------------------- //
 
     function appendParameter(parameters, paramName, paramValue) {
@@ -213,6 +232,7 @@ var MBReleaseImportHelper = (function() {
        buildSearchLink: fnBuildSearchLink,
        buildFormHTML: fnBuildFormHTML,
        buildFormParameters: fnBuildFormParameters,
+       makeArtistCredits: fnArtistCredits,
        URL_TYPES: url_types
     };
 })();

--- a/lib/import_functions.js
+++ b/lib/import_functions.js
@@ -61,6 +61,13 @@ var MBReleaseImportHelper = (function() {
 
     // --------------------------------------- publics ----------------------------------------- //
 
+    var url_types = {
+       purchase_for_download: 74,
+       download_for_free: 75,
+       stream_for_free: 85,
+       license: 301
+    }
+
     // compute HTML of search link
     function fnBuildSearchLink(release) {
 
@@ -203,8 +210,9 @@ var MBReleaseImportHelper = (function() {
     // ---------------------------------- expose publics here ------------------------------------ //
 
     return {
-                buildSearchLink: fnBuildSearchLink,
-                buildFormHTML: fnBuildFormHTML,
-                buildFormParameters: fnBuildFormParameters
-            };
+       buildSearchLink: fnBuildSearchLink,
+       buildFormHTML: fnBuildFormHTML,
+       buildFormParameters: fnBuildFormParameters,
+       URL_TYPES: url_types
+    };
 })();


### PR DESCRIPTION
Fixed:
- invisible import button
- more tracks than in the release
- release artist credit were the ones of the last track
- remove 'Original Mix' from track titles
- update jquery to recent version
- prevent jquery conflicts
- use relative paths for lib