### PR TITLE
bandcamp_importer: support bandcamp pages having their own domain

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -5,8 +5,7 @@
 // @namespace      http://userscripts.org/users/22504
 // @downloadURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL      https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
-// @include        http*://*.bandcamp.com/album/*
-// @include        http*://*.bandcamp.com/track/*
+// @include        /^https?://[^/]+/(?:album|track)/[^/]+$/
 // @require        https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js
 // @require        lib/import_functions.js
 // @require        lib/logger.js
@@ -209,6 +208,14 @@ var BandcampImport = {
 };
 
 $(document).ready(function () {
+  /* keep the following line as first, it is required to skip
+   * pages which aren't actually a bandcamp page, since we support
+   * bandcamp pages under third-party domains.
+   * see @include
+   */
+  if (!unsafeWindow.TralbumData) return;
+  /***/
+
   MBImportStyle();
 
   var mblinks = new MBLinks('BCI_MBLINKS_CACHE');


### PR DESCRIPTION
Currently, one has to add the domain to userscript preferences for pages provided by bandcamp
but under another domain (ie. http://bearthemammoth.com/album/yamadori)

This change makes the `@include` wider (it may match totally unrelated pages) and test for
a bandcamp-specific object before doing anything.

Please review and test, i'm still not sure if it is a good idea, but it simplifies things since nowaday a lot of artists/labels are using bandcamp engine with their own domains.

Another approach would be to make 2 userscripts with different include rules, sharing the same code.