### PR TITLE
Discogs importer: display links for direct search of entities on MB

### DIFF
--- a/discogs_importer.user.js
+++ b/discogs_importer.user.js
@@ -42,6 +42,7 @@ var mblinks = new MBLinks('DISCOGS_MBLINKS_CACHE', 7*24*60, '1'); // force refre
 $(document).ready(function(){
 
     MBImportStyle();
+    MBSearchItStyle();
 
     var current_page_key = getDiscogsLinkKey(window.location.href.replace(/\?.*$/, '').replace(/#.*$/, '').replace('/master/view/', '/master/'));
     if (!current_page_key) return;
@@ -86,7 +87,7 @@ $(document).ready(function(){
 // Insert MusicBrainz links in a section of the page
 function insertMBLinks($root) {
 
-    function searchAndDisplayMbLinkInSection($tr, discogs_type, mb_type) {
+    function searchAndDisplayMbLinkInSection($tr, discogs_type, mb_type, nosearch) {
         if (!mb_type) mb_type = defaultMBtype(discogs_type);
         $tr.find('a[mlink^="' + discogs_type + '/"]').each(function() {
             var $link = $(this);
@@ -102,10 +103,41 @@ function insertMBLinks($root) {
             if (link_infos[mlink] && link_infos[mlink].type == discogs_type) {
               var discogs_url = link_infos[mlink].clean_url;
               var cachekey = getCacheKeyFromInfo(mlink, mb_type);
-              var insert_func = function (link) { $link.before(link); }
+              var has_wrapper = $link.closest('span.mb_wrapper').length;
+              if (!has_wrapper) {
+                $link.wrap('<span class="mb_wrapper"><span class="mb_valign"></span></span>');
+              }
+              if (!nosearch) {
+                // add search link for the current link text
+                var entities = {
+                  'artist': { mark: 'A'},
+                  'release': { mark: 'R'},
+                  'release-group': { mark: 'G'},
+                  'place': { mark: 'P'},
+                  'label': { mark: 'L'}
+                }
+                var mark = '';
+                var entity_name = 'entity';
+                if (mb_type in entities) {
+                  mark = entities[mb_type].mark;
+                  entity_name = mb_type.replace(/[_-]/g, ' ');
+                }
+                $link.closest('span.mb_wrapper').prepend('<span class="mb_valign mb_searchit"><a class="mb_search_link" target="_blank" title="Search this '+ entity_name + ' on MusicBrainz (open in a new tab)" href="' + MBReleaseImportHelper.searchUrlFor(mb_type, $link.text()) + '"><small>'+mark+'</small>?</a></span>');
+              }
+              var insert_normal = function (link) {
+                $link.closest('span.mb_valign').before('<span class="mb_valign">'+link+'</span>');
+                $link.closest('span.mb_wrapper').find('.mb_searchit').remove();
+              };
+
+              var insert_stop = function (link) {
+                insert_normal(link);
+                $link.attr('mlink_stop', true);
+              };
+
+              var insert_func = insert_normal;
               if (mb_type == 'place') {
                 // if a place link was added we stop, we don't want further queries for this 'label'
-                insert_func = function (link) { $link.before(link); $link.attr('mlink_stop', true); }
+                insert_func = insert_stop;
               }
               mblinks.searchAndDisplayMbLink(discogs_url, mb_type, insert_func, cachekey);
             }
@@ -145,7 +177,7 @@ function insertMBLinks($root) {
     }
 
     var add_mblinks_counter = 0;
-    function add_mblinks(_root, selector, types) {
+    function add_mblinks(_root, selector, types, nosearch) {
       // types can be:
       // 'discogs type 1'
       // ['discogs_type 1', 'discogs_type 2']
@@ -173,7 +205,7 @@ function insertMBLinks($root) {
           $.each(types, function (idx, val) {
             var discogs_type = val[0];
             var mb_type = val[1];
-            searchAndDisplayMbLinkInSection($(that), discogs_type, mb_type);
+            searchAndDisplayMbLinkInSection($(that), discogs_type, mb_type, nosearch);
           });
       });
     }
@@ -186,7 +218,7 @@ function insertMBLinks($root) {
     add_mblinks($root, 'div#tracklist', 'artist');
     add_mblinks($root, 'div#companies', [['label', 'place'], 'label']);
     add_mblinks($root, 'div#credits', ['label', 'artist']);
-    add_mblinks($root, 'div#page_aside div.section_content:first', 'master');
+    add_mblinks($root, 'div#page_aside div.section_content:first', 'master', true);
 }
 
 

--- a/lib/import_functions.js
+++ b/lib/import_functions.js
@@ -101,6 +101,17 @@ var MBReleaseImportHelper = (function() {
         return '<a class="musicbrainz_import" href="//musicbrainz.org/search?' + params.join('&') + '">Search in MusicBrainz</a>';
     }
 
+    function fnSearchUrlFor(type, what) {
+      type = type.replace('-', '_');
+
+      var params = [
+          'query=' + luceneEscape(what),
+          'type=' + type,
+          'indexed=1'
+        ];
+        return '//musicbrainz.org/search?' + params.join('&');
+    }
+
     // compute HTML of import form
     function fnBuildFormHTML(parameters) {
 
@@ -345,6 +356,7 @@ var MBReleaseImportHelper = (function() {
        guessReleaseType: fnGuessReleaseType,
        hmsToMilliSeconds: hmsToMilliSeconds,
        ISO8601toMilliSeconds: fnISO8601toMilliSeconds,
+       searchUrlFor: fnSearchUrlFor,
        URL_TYPES: url_types
     };
 })();

--- a/lib/mbimportstyle.js
+++ b/lib/mbimportstyle.js
@@ -32,3 +32,37 @@ function MBImportStyle() {
   ";
   _add_css(css_import_button);
 }
+
+function MBSearchItStyle() {
+  var css_search_it = " \
+   .mb_valign {  \
+     display: inline-block;  \
+     vertical-align: top;  \
+   }  \
+   .mb_searchit {  \
+     width: 16px;  \
+     height: 16px;  \
+     margin: 0;  \
+     padding: 0;  \
+     background-color: #FFF7BE;  \
+     border: 0px;  \
+     vertical-align: top;  \
+     font-size: 11px;  \
+     text-align: center;  \
+   }  \
+   a.mb_search_link {  \
+     color: #888;  \
+     text-decoration: none;  \
+   }  \
+   a.mb_search_link small {  \
+     font-size: 8px;  \
+   }  \
+   .mb_searchit a.mb_search_link:hover {  \
+     color: darkblue;  \
+   }  \
+   .mb_wrapper {  \
+     display: inline-block;  \
+   }  \
+   ";
+   _add_css(css_search_it);
+}


### PR DESCRIPTION
While an entity is not found, display a small link which allows one to query MB for this entity.
For the case the discogs element may match more than one MB entities (ie. label or place), one search link for each is displayed (at the moment only in release > companies).

![capture du 2015-06-14 22 01 56](https://cloud.githubusercontent.com/assets/151042/8150221/adb33dc2-12e1-11e5-9097-af4caf3cbae8.png)
