### PR TITLE
Use https urls when querying musicbrainz

### DIFF
--- a/discogs_importer.user.js
+++ b/discogs_importer.user.js
@@ -291,7 +291,7 @@ function getDiscogsLinkKey(url) {
         link_infos[key] = {
           type: m[1],
           id: m[2],
-          clean_url: 'http://www.discogs.com/' + m[1] + '/' + m[2]
+          clean_url: 'https://www.discogs.com/' + m[1] + '/' + m[2]
         }
         LOGGER.debug('getDiscogsLinkKey:' + url + ' --> ' + key);
       } else {


### PR DESCRIPTION
Musicbrainz no longer normalizes discogs URLs to http, so we now need to search for the https form.

Fixes #124