### PR TITLE
Update Beatport scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,19 @@ Add a link to Bandcamp's album canonical URL on pages without /album/, for one t
 [![Source](https://github.com/jerone/UserScripts/blob/master/_resources/Source-button.png)](https://github.com/murdos/musicbrainz-userscripts/blob/master/bandcamp_importer_helper.user.js)
 [![Install](https://raw.github.com/jerone/UserScripts/master/_resources/Install-button.png)](https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer_helper.user.js)
 
-## <a name="beatport_pro_importer"></a> Import Beatport Pro releases to MusicBrainz
-
-One-click importing of releases from pro.beatport.com/release pages into MusicBrainz
-
-[![Source](https://github.com/jerone/UserScripts/blob/master/_resources/Source-button.png)](https://github.com/murdos/musicbrainz-userscripts/blob/master/beatport_pro_importer.user.js)
-[![Install](https://raw.github.com/jerone/UserScripts/master/_resources/Install-button.png)](https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_pro_importer.user.js)
-
 ## <a name="beatport_importer"></a> Import Beatport releases to MusicBrainz
 
 One-click importing of releases from beatport.com/release pages into MusicBrainz
 
 [![Source](https://github.com/jerone/UserScripts/blob/master/_resources/Source-button.png)](https://github.com/murdos/musicbrainz-userscripts/blob/master/beatport_importer.user.js)
 [![Install](https://raw.github.com/jerone/UserScripts/master/_resources/Install-button.png)](https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_importer.user.js)
+
+## <a name="beatport_classic_importer"></a> Import Beatport Classic releases to MusicBrainz
+
+One-click importing of releases from classic.beatport.com/release pages into MusicBrainz
+
+[![Source](https://github.com/jerone/UserScripts/blob/master/_resources/Source-button.png)](https://github.com/murdos/musicbrainz-userscripts/blob/master/beatport_classic_importer.user.js)
+[![Install](https://raw.github.com/jerone/UserScripts/master/_resources/Install-button.png)](https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_classic_importer.user.js)
 
 ## <a name="cdbaby_importer"></a> Import CD Baby releases to MusicBrainz
 

--- a/beatport_classic_importer.user.js
+++ b/beatport_classic_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           Import Beatport Classic releases to MusicBrainz
 // @description    One-click importing of releases from classic.beatport.com/release pages into MusicBrainz
-// @version        2015.07.14.0
+// @version        2017.06.13.0
 // @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_classic_importer.user.js
 // @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_classic_importer.user.js
 // @include        http*://classic.beatport.com/release/*

--- a/beatport_classic_importer.user.js
+++ b/beatport_classic_importer.user.js
@@ -37,9 +37,6 @@ function retrieveReleaseInfo(release_url) {
   var release_date_strings = [
     'Release Date', 'Fecha de lanzamiento', 'Date de sortie', 'Erscheinungsdatum', 'Data de lançamento', 'Releasedatum', "Data di uscita", "リリース予定日"
   ];
-  var release_strings = [
-    'Release', 'Lanzamiento', 'Sortie', 'Album', 'Lançamento'
-  ];
   var labels_strings = [
     'Labels', 'Sello', 'Gravadoras', "Label", "Etichetta", "Editora", "レーベル"
   ];
@@ -82,13 +79,13 @@ function retrieveReleaseInfo(release_url) {
 
       var artists = [];
       t.artists.forEach(
-        function ( artist, index, arr ) {
+        function (artist) {
           artists.push(artist.name);
 	  release_artists.push(artist.name);
         }
       );
       var title = t.name;
-      if (t.mixName && t.mixName != 'Original Mix' && t.mixName != 'Original') {
+      if (t.mixName && t.mixName !== 'Original Mix' && t.mixName !== 'Original') {
         title += ' (' + t.mixName + ')';
       }
       tracks.push({

--- a/beatport_classic_importer.user.js
+++ b/beatport_classic_importer.user.js
@@ -2,8 +2,8 @@
 // @name           Import Beatport Classic releases to MusicBrainz
 // @description    One-click importing of releases from classic.beatport.com/release pages into MusicBrainz
 // @version        2015.07.14.0
-// @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_importer.user.js
-// @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_importer.user.js
+// @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_classic_importer.user.js
+// @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_classic_importer.user.js
 // @include        http*://classic.beatport.com/release/*
 // @require        https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js
 // @require        lib/mbimport.js

--- a/beatport_importer.user.js
+++ b/beatport_importer.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
-// @name           Import Beatport releases to MusicBrainz
-// @description    One-click importing of releases from beatport.com/release pages into MusicBrainz
+// @name           Import Beatport Classic releases to MusicBrainz
+// @description    One-click importing of releases from classic.beatport.com/release pages into MusicBrainz
 // @version        2015.07.14.0
 // @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_importer.user.js
 // @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_importer.user.js
@@ -123,7 +123,7 @@ function retrieveReleaseInfo(release_url) {
 
 // Insert button into page under label information
 function insertLink(release, release_url) {
-    var edit_note = MBImport.makeEditNote(release_url, 'BeatPort');
+    var edit_note = MBImport.makeEditNote(release_url, 'Beatport Classic');
     var parameters = MBImport.buildFormParameters(release, edit_note);
 
     var mbUI = $('<div class="musicbrainz-import">'

--- a/beatport_importer.user.js
+++ b/beatport_importer.user.js
@@ -47,7 +47,7 @@ function retrieveReleaseInfo(release_url) {
     type: '',
     urls: [],
     labels: [],
-    discs: [],
+    discs: []
   };
 
   // URLs
@@ -70,7 +70,7 @@ function retrieveReleaseInfo(release_url) {
   var release_artists = [];
   $.each(the_tracks,
     function (idx, track) {
-      if (track.release.id != ProductDetail.id) {
+      if (track.release.id !== ProductDetail.id) {
         return;
       }
       if (seen_tracks[track.id]) {
@@ -87,7 +87,7 @@ function retrieveReleaseInfo(release_url) {
       );
 
       var title = track.name;
-      if (track.mix && track.mix != 'Original Mix') {
+      if (track.mix && track.mix !== 'Original Mix') {
         title += ' (' + track.mix + ')';
       }
       tracks.push({

--- a/beatport_importer.user.js
+++ b/beatport_importer.user.js
@@ -4,8 +4,8 @@
 // @namespace      https://github.com/murdos/musicbrainz-userscripts/
 // @description    One-click importing of releases from beatport.com/release pages into MusicBrainz
 // @version        2015.07.14.0
-// @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_pro_importer.user.js
-// @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_pro_importer.user.js
+// @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_importer.user.js
+// @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_importer.user.js
 // @include        http://www.beatport.com/release/*
 // @include        https://www.beatport.com/release/*
 // @require        https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js

--- a/beatport_importer.user.js
+++ b/beatport_importer.user.js
@@ -3,7 +3,7 @@
 // @author         VxJasonxV
 // @namespace      https://github.com/murdos/musicbrainz-userscripts/
 // @description    One-click importing of releases from beatport.com/release pages into MusicBrainz
-// @version        2015.07.14.0
+// @version        2017.06.13.0
 // @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_importer.user.js
 // @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_importer.user.js
 // @include        http://www.beatport.com/release/*

--- a/beatport_pro_importer.user.js
+++ b/beatport_pro_importer.user.js
@@ -36,9 +36,6 @@ function retrieveReleaseInfo(release_url) {
     });
     return selectors.join(',');
   }
-  var release_date_strings = [
-    'Release Date', 'Fecha de lanzamiento', 'Date de sortie', 'Veröffentlichungsdatum', 'Data de lançamento', 'Releasedatum'
-  ];
   var release_strings = [
     'Release', 'Lanzamiento', 'Sortie', 'Album', 'Lançamento'
   ];
@@ -48,7 +45,7 @@ function retrieveReleaseInfo(release_url) {
   var catalog_strings = [
     'Catalog', 'Catálogo', 'Catalogue', 'Katalog', 'Catalogus'
   ];
-  var releaseDate = $(contains_or(".category", release_date_strings)).next().text().split("-");
+  var releaseDate = ProductDetail.date.published.split("-");
 
   // Release information global to all Beatport releases
   var release = {

--- a/beatport_pro_importer.user.js
+++ b/beatport_pro_importer.user.js
@@ -69,8 +69,6 @@ function retrieveReleaseInfo(release_url) {
     discs: [],
   };
 
-  var release_id = $( "span.playable-play-all[data-release]" ).attr('data-release');
-
   // URLs
   release.urls.push({
     'url': release_url,
@@ -91,7 +89,7 @@ function retrieveReleaseInfo(release_url) {
   var release_artists = [];
   $.each(the_tracks,
     function (idx, track) {
-      if (track.release.id != release_id) {
+      if (track.release.id != ProductDetail.id) {
         return;
       }
       if (seen_tracks[track.id]) {

--- a/beatport_pro_importer.user.js
+++ b/beatport_pro_importer.user.js
@@ -1,13 +1,13 @@
 // ==UserScript==
-// @name           Import Beatport Pro releases to MusicBrainz
+// @name           Import Beatport releases to MusicBrainz
 // @author         VxJasonxV
 // @namespace      https://github.com/murdos/musicbrainz-userscripts/
-// @description    One-click importing of releases from pro.beatport.com/release pages into MusicBrainz
+// @description    One-click importing of releases from beatport.com/release pages into MusicBrainz
 // @version        2015.07.14.0
 // @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_pro_importer.user.js
 // @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_pro_importer.user.js
-// @include        http://pro.beatport.com/release/*
-// @include        https://pro.beatport.com/release/*
+// @include        http://www.beatport.com/release/*
+// @include        https://www.beatport.com/release/*
 // @require        https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js
 // @require        lib/mbimport.js
 // @require        lib/logger.js
@@ -142,7 +142,7 @@ function retrieveReleaseInfo(release_url) {
 
 // Insert button into page under label information
 function insertLink(release, release_url) {
-    var edit_note = MBImport.makeEditNote(release_url, 'BeatPort Pro');
+    var edit_note = MBImport.makeEditNote(release_url, 'Beatport');
     var parameters = MBImport.buildFormParameters(release, edit_note);
 
     var mbUI = $('<li class="interior-release-chart-content-item musicbrainz-import">'

--- a/beatport_pro_importer.user.js
+++ b/beatport_pro_importer.user.js
@@ -36,9 +36,6 @@ function retrieveReleaseInfo(release_url) {
     });
     return selectors.join(',');
   }
-  var release_strings = [
-    'Release', 'Lanzamiento', 'Sortie', 'Album', 'Lançamento'
-  ];
   var labels_strings = [
     'Labels', 'Compañías discográficas', 'Gravadoras'
   ];
@@ -50,7 +47,7 @@ function retrieveReleaseInfo(release_url) {
   // Release information global to all Beatport releases
   var release = {
     artist_credit: [],
-    title: $(contains_or("h3.interior-type", release_strings)).next().text().trim(),
+    title: ProductDetail.name,
     year: releaseDate[0],
     month: releaseDate[1],
     day: releaseDate[2],

--- a/beatport_pro_importer.user.js
+++ b/beatport_pro_importer.user.js
@@ -29,19 +29,6 @@ $(document).ready(function(){
 });
 
 function retrieveReleaseInfo(release_url) {
-  function contains_or(selector, list) {
-    selectors = [];
-    $.each(list, function(ind, value) {
-      selectors.push(selector + ':contains("' + value.replace('"', '\\"') + '")');
-    });
-    return selectors.join(',');
-  }
-  var labels_strings = [
-    'Labels', 'Compañías discográficas', 'Gravadoras'
-  ];
-  var catalog_strings = [
-    'Catalog', 'Catálogo', 'Catalogue', 'Katalog', 'Catalogus'
-  ];
   var releaseDate = ProductDetail.date.published.split("-");
 
   // Release information global to all Beatport releases
@@ -71,8 +58,8 @@ function retrieveReleaseInfo(release_url) {
 
   release.labels.push(
     {
-      name: $(contains_or(".category", labels_strings)).next().text().trim(),
-      catno: $(contains_or(".category", catalog_strings)).next().text().trim()
+      name: ProductDetail.label.name,
+      catno: ProductDetail.catalog
     }
   );
 


### PR DESCRIPTION
Changed all references to Beatport to use the current names of the services. Fixed the broken Beatport (Pro) script by using the `ProductDetail` object instead of a bunch of parsings that didn't work. Also fixed an unused variable, a left-over comma and non-strict comparisons.

`ProductDetail` could probably be used for more, I only fixed what was broken.

Makes #130 obsolete. Fixes #125. Doesn't fix(!) #62 which is still an issue for me.

Minor note: Beatport keeps (under `date`) both `published` and `released` values. I figure that they could possibly be meant to be used for the date published on Beatport and worldwide release date respectively, so I used `published`. I haven't found any documentation or releases where the values are different from each other, even though some were [clearly](https://www.beatport.com/release/acro-cog-dis-theo/2033667) neither published nor released on the entered date, so the feature might be entirely unused.