### PR TITLE
Check target type in shorcut for relationships

### DIFF
--- a/mb_relationship_shortcuts.user.js
+++ b/mb_relationship_shortcuts.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           Display shortcut for relationships on MusicBrainz
 // @description    Display icon shortcut for relationships of release-group, release, recording and work: e.g. Amazon, Discogs, Wikipedia, ... links. This allows to access some relationships without opening the entity page.
-// @version        2017.11.12.1
+// @version        2018.02.11.0
 // @author         Aurelien Mino <aurelien.mino@gmail.com>
 // @licence        GPL (http://www.gnu.org/copyleft/gpl.html)
 // @downloadURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/mb_relationship_shortcuts.user.js
@@ -142,6 +142,10 @@ $(document).ready(function(){
             $(this).find("relation-list[target-type!='url']").each(function() {
                 var targettype = $(this).attr("target-type").replace("release_group", "release-group");
                 var relations = {};
+
+                if (relationsIconsURLs[targettype] === undefined) {
+                    return;
+                }
 
                 $(this).children("relation").each(function() {
                     var reltype = $(this).attr("type");


### PR DESCRIPTION
Issue: `mb_relationship_shortcuts.user.js` triggers the following exception under certain circumstances:

````
TypeError
relationsIconsURLs[targettype] is undefined
````

This patch tests if the `targettype` is appropriate for relationships shortcut display.