### PR TITLE
URGENT: Recording comment removal edits are queued!

### DIFF
--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           MusicBrainz: Set recording comments for a release
 // @description    Batch set recording comments from a Release page.
-// @version        2016.5.30
+// @version        2018.2.17
 // @author         Michael Wiencek
 // @license        X11
 // @namespace      790382e7-8714-47a7-bfbd-528d0caa2333
@@ -81,7 +81,7 @@ function setRecordingComments() {
         var release = location.pathname.match(MBID_REGEX)[0];
 
         $.get("/ws/2/release/" + release + "?inc=recordings&fmt=json", function (data) {
-            var comments = _.pluck(_.pluck(_.flatten(_.pluck(data.media, "tracks")), "recording"), "disambiguation");
+            var comments = _.map(_.map(_.flatten(_.map(data.media, "tracks")), "recording"), "disambiguation");
 
             for (var i = 0, len = comments.length; i < len; i++) {
                 var comment = comments[i];

--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -7,15 +7,10 @@
 // @namespace      790382e7-8714-47a7-bfbd-528d0caa2333
 // @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/set-recording-comments.user.js
 // @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/set-recording-comments.user.js
-// @include        *://musicbrainz.org/release/*
-// @include        *://beta.musicbrainz.org/release/*
-// @include        *://*.mbsandbox.org/release/*
-// @match          *://musicbrainz.org/release/*
-// @match          *://beta.musicbrainz.org/release/*
+// @match          *://*.musicbrainz.org/release/*
 // @match          *://*.mbsandbox.org/release/*
-// @exclude        *://musicbrainz.org/release/*/*
-// @exclude        *://beta.musicbrainz.org/release/*/*
-// @exclude        *://*.mbsandbox.org/release/*/*
+// @exclude        *musicbrainz.org/release/*/*
+// @exclude        *.mbsandbox.org/release/*/*
 // @grant          none
 // ==/UserScript==
 


### PR DESCRIPTION
Script does no longer fetch recording comments for edit.
It’s ending up in submitting recording comment removal edits!
Because of `_.pluck is not a function` issue.

---

I have also cleaned up <del>`@include`</del>, `@exclude` and `@match`.