### PR TITLE
Fixing my old date mistake that makes old users stay on the old version

### DIFF
--- a/fast-cancel-edits.user.js
+++ b/fast-cancel-edits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        MusicBrainz: Fast cancel edits
 // @description Mass cancel open edits with optional edit notes.
-// @version     2015.6.7
+// @version     2016.6.7
 // @author      Michael Wiencek
 // @license     X11
 // @downloadURL https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/fast-cancel-edits.user.js


### PR DESCRIPTION
I’m just fixing the version number that went down instead of moving up with a82234ebf031203e25f8246e4634277acb0cdc9c, that was made in <ins>2016</ins>-06-07, not in <del>2015</del>-06-07 — [spotted by psychoadept](https://community.metabrainz.org/t/your-favourite-user-scripts-for-musicbrainz-so-that-they-can-be-used-while-redesigning/354379/30?u=jesus2099).