### PR TITLE
Fix update version to make sub-version numbers without leading 0

### DIFF
--- a/mb_relationship_shortcuts.user.js
+++ b/mb_relationship_shortcuts.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           Display shortcut for relationships on MusicBrainz
 // @description    Display icon shortcut for relationships of release-group, release, recording and work: e.g. Amazon, Discogs, Wikipedia, ... links. This allows to access some relationships without opening the entity page.
-// @version        2018.02.11.0
+// @version        2018.2.17.1
 // @author         Aurelien Mino <aurelien.mino@gmail.com>
 // @licence        GPL (http://www.gnu.org/copyleft/gpl.html)
 // @downloadURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/mb_relationship_shortcuts.user.js

--- a/tools/update_version.py
+++ b/tools/update_version.py
@@ -26,7 +26,7 @@ To test without modifying file, use stdin:
 def make_version_line(old_value='0.0.0.0', spacing=' '*8, eol="\n"):
     prev_version = [int(x) for x in old_value.split('.')]
     now = datetime.datetime.utcnow()
-    version = [now.year, now.month, now.day, 0]
+    version = [now.year, now.month, now.day, 1]
     if prev_version[:3] == version[:3]:
         version[3] = prev_version[3] + 1
     version_str = '%04d.%02d.%02d.%d' % tuple(version)

--- a/tools/update_version.py
+++ b/tools/update_version.py
@@ -29,7 +29,7 @@ def make_version_line(old_value='0.0.0.0', spacing=' '*8, eol="\n"):
     version = [now.year, now.month, now.day, 1]
     if prev_version[:3] == version[:3]:
         version[3] = prev_version[3] + 1
-    version_str = '%04d.%02d.%02d.%d' % tuple(version)
+    version_str = '%04d.%d.%d.%d' % tuple(version)
     return ('// @version' + spacing + version_str + eol, version_str)
 
 


### PR DESCRIPTION
As reported by @jesus2099 in https://github.com/murdos/musicbrainz-userscripts/commit/b365af8cde4117cd65bb2f8274b5c0bb7e83d9a8#commitcomment-27623531 and https://github.com/murdos/musicbrainz-userscripts/commit/b365af8cde4117cd65bb2f8274b5c0bb7e83d9a8#commitcomment-27605542, version part numbers starting with `0` are not supported by Chrome at least.

This patch fixes the tool to update version so as to stop padding month and day with leading `0` and to start the fourth number/part of version from `1` instead of `0`.

As ane example, it also bumps version number for recently updated `mb_relationship_shortcuts.user.js` which caused this bug to be reported.

If this patch does not generate other any auto update bug for other platform/browser, it should be fine to bump the version number of every other script with such unsupported version number.