### PR TITLE
Discog importer: Turn all acute accents used as apostrophe into the proper character

### DIFF
--- a/discogs_importer.user.js
+++ b/discogs_importer.user.js
@@ -2,7 +2,7 @@
 
 // @name           Import Discogs releases to MusicBrainz
 // @description    Add a button to import Discogs releases to MusicBrainz and add links to matching MusicBrainz entities for various Discogs entities (artist,release,master,label)
-// @version        2017.02.25.0
+// @version        2018.2.28
 // @namespace      http://userscripts.org/users/22504
 // @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/discogs_importer.user.js
 // @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/discogs_importer.user.js
@@ -599,7 +599,7 @@ function parseDiscogsRelease(data) {
 
         var track = new Object();
 
-        track.title = discogsTrack.title;
+        track.title = discogsTrack.title.replace(/´/g, '’');
         track.duration = MBImport.hmsToMilliSeconds(discogsTrack.duration); // MB in milliseconds
 
         // Track artist credit


### PR DESCRIPTION
Acute accents are wrong and they also make the MB track parser add spaces around it.
Example https://www.discogs.com/release/7809058 → https://musicbrainz.org/edit/51145485
This is only small change proposal on track titles but if wanted,
it should be done for track artists and release title and artists as well.
Maybe as a new cleanup function.
Tell me.