### PR TITLE
mbimport.js: Add support for disambiguation comment

### DIFF
--- a/lib/mbimport.js
+++ b/lib/mbimport.js
@@ -29,6 +29,7 @@
  *         day,
  *         labels = [ { name, mbid, catno }, ... ],
  *         barcode,
+ *         comment,
  *         urls = [ {url, link_type }, ... ],
  *         discs = [
  *             {
@@ -182,6 +183,9 @@ var MBImport = (function() {
 
         // Barcode
         appendParameter(parameters, 'barcode', release.barcode);
+
+        // Disambiguation comment
+        appendParameter(parameters, 'comment', release.comment);
 
         // Label + catnos
         for (var i = 0; i < release.labels.length; i++) {


### PR DESCRIPTION
I used "Digital download" as a release.comment on recent qobuz_importer.user.js updates. This will add support for passing the comment to MusicBrainz release editor seeding.