### PR TITLE
Spotify importer: spotify_importer.user.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 -   [MusicBrainz: Set recording comments for a release](#set-recording-comments)
 -   [Musicbrainz DiscIds Detector](#mb_discids_detector)
 -   [Musicbrainz UI enhancements](#mb_ui_enhancements)
+-   [MusicBrainz: Add recording edit links to instrument pages](#edit-instrument-recordings-links)
 
 ## <a name="mb_relationship_shortcuts"></a> Display shortcut for relationships on MusicBrainz
 
@@ -176,3 +177,10 @@ Various UI enhancements for Musicbrainz
 
 [![Source](https://github.com/jerone/UserScripts/blob/master/_resources/Source-button.png)](https://github.com/murdos/musicbrainz-userscripts/blob/master/mb_ui_enhancements.user.js)
 [![Install](https://raw.github.com/jerone/UserScripts/master/_resources/Install-button.png)](https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/mb_ui_enhancements.user.js)
+
+## <a name="edit-instrument-recordings-links"></a> MusicBrainz: Add recording edit links to instrument pages
+
+Direct links to the recording edit page are added to instruments' recordings pages.
+
+[![Source](https://github.com/jerone/UserScripts/blob/master/_resources/Source-button.png)](https://github.com/murdos/musicbrainz-userscripts/blob/master/edit-instrument-recordings-links.user.js)
+[![Install](https://raw.github.com/jerone/UserScripts/master/_resources/Install-button.png)](https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/edit-instrument-recordings-links.user.js)

--- a/deezer_importer.user.js
+++ b/deezer_importer.user.js
@@ -1,0 +1,145 @@
+// ==UserScript==
+// @name           Import Deezer releases into MusicBrainz
+// @namespace      https://github.com/murdos/musicbrainz-userscripts/
+// @description    One-click importing of releases from deezer.com into MusicBrainz
+// @version        2019.1.30.1
+// @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/deezer_importer.user.js
+// @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/deezer_importer.user.js
+// @include        http*://www.deezer.com/*/album/*
+// @require        https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js
+// @require        lib/mbimport.js
+// @require        lib/logger.js
+// @require        lib/mbimportstyle.js
+// @icon           https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png
+// @grant          GM_xmlhttpRequest
+// @grant          GM.xmlHttpRequest
+// ==/UserScript==
+
+// prevent JQuery conflicts, see http://wiki.greasespot.net/@grant
+this.$ = this.jQuery = jQuery.noConflict(true);
+
+$(document).ready(function() {
+    let gmXHR;
+
+    if (typeof GM_xmlhttpRequest != 'undefined') {
+        gmXHR = GM_xmlhttpRequest;
+    } else if (GM.xmlHttpRequest != 'undefined') {
+        gmXHR = GM.xmlHttpRequest;
+    } else {
+        LOGGER.error('Userscript requires GM_xmlHttpRequest or GM.xmlHttpRequest');
+        return;
+    }
+
+    // allow 1 second for Deezer SPA to initialize
+    window.setTimeout(function() {
+        MBImportStyle();
+        let releaseUrl = window.location.href.replace(/\?.*$/, '').replace(/#.*$/, '');
+        let releaseId = releaseUrl.replace(/^https?:\/\/www\.deezer\.com\/[^/]+\/album\//i, '');
+        let deezerApiUrl = `https://api.deezer.com/album/${releaseId}`;
+
+        gmXHR({
+            method: 'GET',
+            url: deezerApiUrl,
+            onload: function(resp) {
+                try {
+                    let release = parseDeezerRelease(releaseUrl, JSON.parse(resp.responseText));
+                    insertLink(release, releaseUrl);
+                } catch (e) {
+                    LOGGER.error('Failed to parse release: ', e);
+                }
+            },
+            onerror: function(resp) {
+                LOGGER.error('AJAX status:', resp.status);
+                LOGGER.error('AJAX response:', resp.responseText);
+            }
+        });
+    }, 1000);
+});
+
+function parseDeezerRelease(releaseUrl, data) {
+    let releaseDate = data.release_date.split('-');
+
+    let release = {
+        artist_credit: [],
+        title: data.title,
+        year: releaseDate[0],
+        month: releaseDate[1],
+        day: releaseDate[2],
+        packaging: 'None',
+        country: 'XW',
+        status: 'official',
+        language: 'eng',
+        script: 'Latn',
+        type: '',
+        urls: [],
+        labels: [],
+        discs: []
+    };
+
+    $.each(data.contributors, function(index, artist) {
+        if (artist.role != 'Main') return true;
+
+        let ac = {
+            artist_name: artist.name,
+            joinphrase: index == data.contributors.length - 1 ? '' : ', '
+        };
+
+        if (artist.name == 'Various Artists') {
+            ac = MBImport.specialArtist('various_artists', ac);
+        }
+
+        release.artist_credit.push(ac);
+    });
+
+    let disc = {
+        format: 'Digital Media',
+        title: '',
+        tracks: []
+    };
+
+    $.each(data.tracks.data, function(index, track) {
+        let t = {
+            number: index + 1,
+            title: track.title_short,
+            duration: track.duration * 1000,
+            artist_credit: []
+        };
+
+        // ignore pointless "(Original Mix)" in title version
+        if (track.title_version && !track.title_version.match(/^\s*\(Original Mix\)\s*$/i)) {
+            t.title += ` ${track.title_version}`;
+        }
+
+        t.artist_credit.push({ artist_name: track.artist.name });
+
+        disc.tracks.push(t);
+    });
+
+    release.discs.push(disc);
+
+    release.urls.push({
+        link_type: MBImport.URL_TYPES.stream_for_free,
+        url: releaseUrl
+    });
+    release.labels.push({ name: data.label });
+    release.type = data.record_type;
+    release.barcode = data.upc;
+
+    return release;
+}
+
+function insertLink(release, release_url) {
+    let editNote = MBImport.makeEditNote(release_url, 'Deezer');
+    let parameters = MBImport.buildFormParameters(release, editNote);
+
+    let mbUI = $(
+        `<div class="toolbar-item">
+            ${MBImport.buildFormHTML(parameters)}
+            </div><div class="toolbar-item">
+            ${MBImport.buildSearchButton(release)}
+            </div>`
+    ).hide();
+
+    $('div.toolbar-wrapper-full').append(mbUI);
+    mbUI.show();
+}

--- a/discogs_importer.user.js
+++ b/discogs_importer.user.js
@@ -810,7 +810,8 @@ var MediaTypes = {
     Vinyl: 'Vinyl',
     'Vinyl7"': '7" Vinyl',
     'Vinyl10"': '10" Vinyl',
-    'Vinyl12"': '12" Vinyl'
+    'Vinyl12"': '12" Vinyl',
+    'Lathe Cut': 'Phonograph record'
 };
 
 var Countries = {
@@ -833,6 +834,7 @@ var Countries = {
     Bahrain: 'BH',
     Bangladesh: 'BD',
     Barbados: 'BB',
+    'Barbados, The': 'BB',
     Belarus: 'BY',
     Belgium: 'BE',
     Belize: 'BZ',

--- a/discogs_importer.user.js
+++ b/discogs_importer.user.js
@@ -1,8 +1,8 @@
-﻿// ==UserScript==
+// ==UserScript==
 
 // @name           Import Discogs releases to MusicBrainz
 // @description    Add a button to import Discogs releases to MusicBrainz and add links to matching MusicBrainz entities for various Discogs entities (artist,release,master,label)
-// @version        2018.7.14.1
+// @version        2019.4.11.1
 // @namespace      http://userscripts.org/users/22504
 // @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/discogs_importer.user.js
 // @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/discogs_importer.user.js
@@ -791,7 +791,7 @@ var MediaTypes = {
     'HD DVD-R': 'HD-DVD',
     Hybrid: 'Other',
     Laserdisc: 'LaserDisc',
-    'Memory Stick': 'Other',
+    'Memory Stick': 'USB Flash Drive',
     Microcassette: 'Other',
     Minidisc: 'MiniDisc',
     MVD: 'Other',

--- a/edit-instrument-recordings-links.user.js
+++ b/edit-instrument-recordings-links.user.js
@@ -1,0 +1,59 @@
+// ==UserScript==
+// @name		MusicBrainz: Add recording edit links to instrument pages
+// @description Direct links to the recording edit page are added to instruments' recordings pages.
+// @version		2019.4.2.1
+// @author		Nicolás Tamargo
+// @license     X11
+// @downloadURL https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/edit-instrument-recordings-links.user.js
+// @updateURL   https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/edit-instrument-recordings-links.user.js
+// @include     *://musicbrainz.org/instrument/*/recordings*
+// @include     *://*.musicbrainz.org/instrument/*/recordings*
+// @grant       none
+// ==/UserScript==
+
+// ==License==
+// Copyright (C) 2019 Nicolás Tamargo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// Except as contained in this notice, the name(s) of the above copyright
+// holders shall not be used in advertising or otherwise to promote the sale,
+// use or other dealings in this Software without prior written
+// authorization.
+// ==/License==
+//**************************************************************************//
+
+// There should be only one of each
+const table = document.getElementsByClassName('tbl')[0];
+const header = table.getElementsByTagName('thead')[0].getElementsByTagName('tr')[0];
+const recordings = table.getElementsByTagName('tbody')[0].getElementsByTagName('tr');
+
+// We add a column to the header to make it less ugly
+const headerColumn = document.createElement('th');
+headerColumn.innerText = 'Edit';
+header.appendChild(headerColumn);
+
+// We add the links to the recordings
+for (let i = 0; i < recordings.length; i++) {
+    const recordingRow = recordings[i];
+    const recordingUrl = recordingRow.childNodes[3].childNodes[0].getAttribute('href');
+    const extraCell = document.createElement('td');
+    extraCell.innerHTML = `<a href="${recordingUrl}/edit">edit</a>`;
+    recordingRow.appendChild(extraCell);
+}

--- a/lib/mbimport.js
+++ b/lib/mbimport.js
@@ -157,7 +157,7 @@ var MBImport = (function() {
         buildArtistCreditsFormParameters(parameters, '', release.artist_credit);
 
         if (release['secondary_types']) {
-            for (var i = 0; i < release.secondary_types.length; i++) {
+            for (let i = 0; i < release.secondary_types.length; i++) {
                 appendParameter(parameters, 'type', release.secondary_types[i]);
             }
         }
@@ -188,7 +188,7 @@ var MBImport = (function() {
         appendParameter(parameters, 'comment', release.comment);
 
         // Label + catnos
-        for (var i = 0; i < release.labels.length; i++) {
+        for (let i = 0; i < release.labels.length; i++) {
             let label = release.labels[i];
             appendParameter(parameters, `labels.${i}.name`, label.name);
             appendParameter(parameters, `labels.${i}.mbid`, label.mbid);
@@ -208,7 +208,7 @@ var MBImport = (function() {
         let total_tracks = 0;
         let total_tracks_with_duration = 0;
         let total_duration = 0;
-        for (var i = 0; i < release.discs.length; i++) {
+        for (let i = 0; i < release.discs.length; i++) {
             let disc = release.discs[i];
             appendParameter(parameters, `mediums.${i}.format`, disc.format);
             appendParameter(parameters, `mediums.${i}.name`, disc.title);
@@ -382,7 +382,7 @@ var MBImport = (function() {
             totaltracks += release.discs[i].tracks.length;
         }
         let release_artist = '';
-        for (var i = 0; i < release.artist_credit.length; i++) {
+        for (let i = 0; i < release.artist_credit.length; i++) {
             let ac = release.artist_credit[i];
             release_artist += ac.artist_name;
             if (typeof ac.joinphrase != 'undefined' && ac.joinphrase != '') {

--- a/lib/mbimport.js
+++ b/lib/mbimport.js
@@ -345,8 +345,7 @@ var MBImport = (function() {
         return (3600 * parseFloat(m[1] || 0) + 60 * parseFloat(m[2] || 0) + parseFloat(m[3] || 0)) * 1000;
     }
 
-    function fnMakeEditNote(release_url, importer_name, format) {
-        let home = 'https://github.com/murdos/musicbrainz-userscripts';
+    function fnMakeEditNote(release_url, importer_name, format, home = 'https://github.com/murdos/musicbrainz-userscripts') {
         return `Imported from ${release_url}${format ? ` (${format})` : ''} using ${importer_name} import script from ${home}`;
     }
 

--- a/mb_discids_detector.user.js
+++ b/mb_discids_detector.user.js
@@ -1,12 +1,12 @@
 ﻿// ==UserScript==
 // @name           Musicbrainz DiscIds Detector
 // @namespace      http://userscripts.org/users/22504
-// @version        2018.7.14.1
+// @version        2019.2.22.1
 // @description    Generate MusicBrainz DiscIds from online EAC logs, and check existence in MusicBrainz database.
 // @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/mb_discids_detector.user.js
 // @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/mb_discids_detector.user.js
 // @include        http://avaxhome.ws/music/*
-// @include        https://apollo.rip/torrents.php?id=*
+// @include        https://orpheus.network/torrents.php?id=*
 // @include        https://passtheheadphones.me/torrents.php?id=*
 // @include        https://redacted.ch/torrents.php?id=*
 // @include        http*://lztr.us/torrents.php?id=*
@@ -27,7 +27,7 @@ var CHECK_IMAGE =
     'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/gD+AP7rGNSCAAAACXBIWXMAAABIAAAASABGyWs+AAAACXZwQWcAAAAQAAAAEABcxq3DAAADKklEQVQ4y32TS2hcZRiGn/8/Z87MNNc2zczEmptO0jSXagJtXCjWhhSEXpCI4EYENy6KG8FFBYtgEbzQ4k5QqNp2VyMtJVGpRU0tGDNoQxvrmCbkMslkSJrJXM6cOef8v4ukQqX4wbP5eL/327wv/M/Em+qNeFO9ASDEwzUPrM+fP8dqOhXqeGJ/f21ddCAYCsfRyFLJvru2mvnh9mTil8am1uJLQ8ceNOhoa+XC8HfMJm81x1q63glV179oBMLVhpQYEiQKzy0VNtZWLs9OT53s6X3qrxPHX+bSyNVNgyujV8lvrDXG2vZ/7oWig64nAY0hwZCCgIRwUGBJRSGbvp6cHH91R33078ODTyNOnXqPxcRl88ibX5wuBJuP5x2BVhop2PwuBA01kn2tJo4HtxfL5DIzZ7+/8MHrOx7tcMQ3I9dwnWKvF+kfTdlVEc/10f59A0HAgMEui90xgxvTLn8u+9SYhXUnNX60smr7z7Jx3wG8UOSZhUI4spJTrGwo0lssZxVSQlOdZGrJYyzpks4qlvLBWhWMHOgb7Mfsq4PfXOvx+bwgk/WxSwrfUwRNQSgAh7oCFB3N1xNllrMK04A5V7PLMOOvCSFMgFzJl6u2Jl8Gx9XkCppSWdEWNWiPGZy9XmIs6WJKKHuasq+p3qlkOwhz9B54dnbOkorOR0yG9gZJ3fP5cNTm4J4Akws+FyfKOK5GCFAatm/T4ObmB7RWxt74k9hrC0LVtLwwmw2FwyY8323hK2iLGnz2U4lMTiHvR04IGiqLxbrS7x/np3NJozoEmcTFTLTz2U7bivTcXNSsFxWHeyyGE2XGZ7x/j7WGyhA0W3e/LU58eiY1N+0IgLc++or1VLLb6hz6MmPGe/M2NFTBzIpH3lYoX6MQhC1NkzV/p2Jp5JX6eP+vn7wxsJnEXXUVnL6T59K7J/u2tR96365oey7nVQTKnsDzNFr5hETBq3ZmbrB47cS5M2+PdTbHmJpL89+OGbv3dLc81n/kWLih+yDhnTGtEcpeXXHSUz/OJ64M3/ojMS3BUw9rI2BsIUxBsLYyEJYC1nNuqawpARrwtwDgHxTwbTT5CxY9AAAALnpUWHRjcmVhdGUtZGF0ZQAAeNozMjCw0DWw0DUyCTEwsDIyszIw0jUwtTIwAABB3gURQfNnBAAAAC56VFh0bW9kaWZ5LWRhdGUAAHjaMzIwsNA1sNA1MggxNLMyNLYyNtM1MLUyMAAAQgUFF56jVzIAAAAASUVORK5CYII%3D';
 
 $(document).ready(function() {
-    if (window.location.host.match(/apollo\.rip|redacted\.ch|passtheheadphones\.me|lztr\.(us|me)|mutracker\.org|notwhat\.cd/)) {
+    if (window.location.host.match(/orpheus\.network|redacted\.ch|passtheheadphones\.me|lztr\.(us|me)|mutracker\.org|notwhat\.cd/)) {
         LOGGER.info('Gazelle site detected');
         gazellePageHandler();
     } else if (window.location.host.match(/avaxhome\.ws/)) {
@@ -122,8 +122,8 @@ function gazellePageHandler() {
                             .attr('onclick')
                             .match(/show_logs/)
                     ) {
-                        if (window.location.host.match(/apollo/)) {
-                            LOGGER.debug('Apollo');
+                        if (window.location.host.match(/orpheus/)) {
+                            LOGGER.debug('Orpheus');
                             var logAction = 'viewlog';
                         } else if (window.location.host.match(/redacted|passtheheadphones/)) {
                             LOGGER.debug('RED');

--- a/qobuz_importer.user.js
+++ b/qobuz_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           Import Qobuz releases to MusicBrainz
 // @description    Add a button on Qobuz's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version        2019.01.05.0
+// @version        2019.03.26.0
 // @namespace      https://github.com/murdos/musicbrainz-userscripts
 // @downloadURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/qobuz_importer.user.js
 // @updateURL      https://raw.github.com/murdos/musicbrainz-userscripts/master/qobuz_importer.user.js
@@ -12,6 +12,7 @@
 // @require        lib/mblinks.js
 // @require        lib/mbimportstyle.js
 // @icon           https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png
+// @run-at         document-start
 // ==/UserScript==
 
 // prevent JQuery conflicts, see http://wiki.greasespot.net/@grant

--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           MusicBrainz: Set recording comments for a release
 // @description    Batch set recording comments from a Release page.
-// @version        2018.2.18.1
+// @version        2019.5.10.1
 // @author         Michael Wiencek
 // @license        X11
 // @namespace      790382e7-8714-47a7-bfbd-528d0caa2333
@@ -136,6 +136,14 @@ function setRecordingComments() {
     <td><textarea id="recording-comments-edit-note" style="width: 32em;" rows="5"></textarea></td>\
   </tr>\
   <tr>\
+    <td colspan="2" class="auto-editor">\
+      <label>\
+        <input id="make-recording-comments-votable" type="checkbox">\
+        Make all edits votable.\
+      </label>\
+    </td>\
+  </tr>\
+  <tr>\
     <td colspan="2">\
       <button id="submit-recording-comments" class="styled-button">Submit changes (visible and marked red)</button>\
     </td>\
@@ -199,12 +207,13 @@ function setRecordingComments() {
             $submitButton.prop('disabled', false).text('Submit changes (marked red)');
         } else {
             let editNote = $('#recording-comments-edit-note').val();
+            let makeVotable = document.getElementById('make-recording-comments-votable').checked;
 
             activeRequest = $.ajax({
                 type: 'POST',
                 url: '/ws/js/edit/create',
                 dataType: 'json',
-                data: JSON.stringify({ edits: editData, editNote: editNote }),
+                data: JSON.stringify({ edits: editData, editNote: editNote, makeVotable: makeVotable }),
                 contentType: 'application/json; charset=utf-8'
             })
                 .always(function() {

--- a/spotify_importer.user.js
+++ b/spotify_importer.user.js
@@ -1,0 +1,226 @@
+// ==UserScript==
+// @name           Import Spotify releases to MusicBrainz
+// @description    Add a button on Spotify's album pages to open MusicBrainz release editor with pre-filled data for the selected release
+// @version        2019.02.10.0
+// @namespace      https://github.com/murdos/musicbrainz-userscripts
+// @downloadURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/spotify_importer.user.js
+// @updateURL      https://raw.github.com/murdos/musicbrainz-userscripts/master/spotify_importer.user.js
+// @include        /^https?://open\.spotify\.com/album/[A-Za-z0-9]+$
+// @require        https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js
+// @require        lib/mbimport.js
+// @require        lib/logger.js
+// @require        lib/mblinks.js
+// @require        lib/mbimportstyle.js
+// @icon           https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png
+// @run-at         document-body
+// ==/UserScript==
+
+// prevent JQuery conflicts, see http://wiki.greasespot.net/@grant
+this.$ = this.jQuery = jQuery.noConflict(true);
+
+const DEBUG = false;
+//DEBUG = true;
+if (DEBUG) {
+    LOGGER.setLevel('debug');
+}
+
+// list of artist ids which should be mapped to Various Artists
+let various_artists_ids = ['0LyfQWJT6nXafLPZqxe9Of'],
+    various_composers_ids = [],
+    album_artist_data = {}, // for switching album artists on classical
+    raw_release_data;
+
+function isVariousArtists(artist) {
+    // Check hard-coded various artist ids
+    if ($.inArray(artist.id, various_artists_ids) != -1 || $.inArray(artist.id, various_composers_ids) != -1) {
+        return true;
+    }
+    /* else if ($.inArray(artist.name, ['Various Artists']) != -1) {
+        // Let's assume various based on name
+        return true;
+    } */
+    return false;
+}
+
+function getPerformers(trackobj) {
+    return trackobj.artists.map(function(v) {
+        return [v.name, [v.type]];
+    });
+}
+
+function parseRelease(data) {
+    console.log(data);
+    let release = {};
+    release.country = 'XW';
+    release.packaging = 'None';
+    release.script = 'Latn';
+    release.status = 'official';
+    release.comment = 'Spotify release';
+
+    release.url = data.external_urls.spotify;
+    release.barcode = data.external_ids.upc;
+    release.type = data.type;
+    if (typeof data.album_type !== 'undefined') {
+        release.secondary_types = [];
+        release.secondary_types.push(data.album_type);
+    }
+
+    release.urls = [];
+    release.urls.push({
+        url: release.url,
+        link_type: MBImport.URL_TYPES.stream_for_free
+    });
+
+    release.labels = [];
+    release.labels.push({
+        name: data.label,
+        catno: '[none]' // no catno on spotify
+    });
+
+    release.discs = [];
+
+    release.title = data.name;
+    release.release_date = data.release_date.split('-');
+    release.year = parseInt(release.release_date[0]);
+    release.month = parseInt(release.release_date[1]);
+    release.day = parseInt(release.release_date[2]);
+
+    if (isVariousArtists(data.artists[0])) {
+        release.artist_credit = [MBImport.specialArtist('various_artists')];
+        album_artist_data.normal_is_various = true;
+    } else {
+        release.artist_credit = MBImport.makeArtistCredits([data.artists[0].name]);
+    }
+
+    let tracks = [],
+        old_media_num = 1;
+    $.each(data.tracks.items, function(index, trackobj) {
+        // check if new media begins
+        if (trackobj.disc_number != old_media_num) {
+            release.discs.push({
+                tracks: tracks,
+                format: 'Digital Media'
+            });
+            old_media_num = trackobj.disc_number;
+            tracks = [];
+        }
+        let track = {};
+        track.title = trackobj.name.replace('"', '"');
+        track.duration = trackobj.duration_ms;
+        let performers = getPerformers(trackobj);
+
+        let artists = [];
+        let featured_artists = [];
+        $.each(performers, function(index, performer) {
+            console.log(performer);
+            if ($.inArray('featured', performer[1]) != -1) {
+                featured_artists.push(performer[0]);
+            } else if ($.inArray('artist', performer[1]) != -1 || $.inArray('Main Artist', performer[1]) != -1) {
+                artists.push(performer[0]);
+            }
+        });
+        console.log(artists);
+        track.artist_credit = MBImport.makeArtistCredits(artists);
+        console.log(track.artist_credit);
+        if (featured_artists.length) {
+            if (track.artist_credit.length) {
+                track.artist_credit[track.artist_credit.length - 1].joinphrase = ' feat. ';
+            }
+            $.merge(track.artist_credit, MBImport.makeArtistCredits(featured_artists));
+        }
+        tracks.push(track);
+    });
+
+    release.discs.push({
+        tracks: tracks,
+        format: 'Digital Media'
+    });
+
+    return release;
+}
+
+function insertErrorMessage(error_data) {
+    let mbErrorMsg = $('<p class="musicbrainz_import">')
+        .append('<h5>MB import</h5>')
+        .append(`<em>Error ${error_data.code}: ${error_data.message}</em>`)
+        .append('<p><strong>This probably means that you have to be logged in to Qobuz for the script to work.');
+    $('header.TrackListHeader').append(mbErrorMsg);
+}
+
+// Insert buttons into the page
+function insertLink(release) {
+    let edit_note = MBImport.makeEditNote(release.url, 'Spotify'),
+        parameters = MBImport.buildFormParameters(release, edit_note),
+        $album_form = $(MBImport.buildFormHTML(parameters)),
+        search_form = MBImport.buildSearchButton(release);
+    let mbUI = $('<p class="musicbrainz_import">')
+        .append($album_form, search_form)
+        .hide();
+
+    let oldUI = $('p.musicbrainz_import');
+    if (oldUI.length) {
+        oldUI.replaceWith(mbUI);
+    } else {
+        $('body').append(mbUI);
+    }
+    mbUI.slideDown();
+
+    $('form.musicbrainz_import img').css({
+        display: 'inline-block',
+        width: '16px',
+        height: '16px'
+    });
+    $('p.musicbrainz_import').css({
+        'z-index': 1000,
+        padding: '5px'
+    });
+    $('.musicbrainz_import button').css({
+        'box-sizing': 'content-box',
+        display: 'flex',
+        'min-width': '110px',
+        'margin-top': '2px'
+    });
+    $('.musicbrainz_import button span').css({
+        width: '100%'
+    });
+}
+
+const send = XMLHttpRequest.prototype.send;
+
+function sendReplacement(data) {
+    /** It seems that the spotify code tweaks the send event,
+     *  so hooking to the onreadystatechange event.
+     */
+    if (this.onreadystatechange) {
+        this._onreadystatechange = this.onreadystatechange;
+    }
+    // console.log(this);
+    this.onreadystatechange = onReadyStateChangeReplacement;
+    return send.apply(this, arguments);
+}
+
+function onReadyStateChangeReplacement() {
+    let wsUrl = 'https://api.spotify.com/v1/albums/',
+        target = arguments[0].target;
+    if (target.responseURL.startsWith(wsUrl) && target.readyState == 4) {
+        raw_release_data = JSON.parse(target.responseText);
+        if (target.status !== 200) {
+            LOGGER.error(raw_release_data);
+            insertErrorMessage(raw_release_data);
+        } else {
+            let release = parseRelease(raw_release_data);
+            insertLink(release);
+        }
+    }
+
+    if (this._onreadystatechange) {
+        return this._onreadystatechange.apply(this, arguments);
+    }
+}
+
+// Hook XMLHttpRequest to use the data fetched from the api by the web-player.
+window.XMLHttpRequest.prototype.send = sendReplacement;
+
+$(document).ready(function() {
+    MBImportStyle();
+});

--- a/spotify_importer.user.js
+++ b/spotify_importer.user.js
@@ -49,7 +49,6 @@ function getPerformers(trackobj) {
 }
 
 function parseRelease(data) {
-    console.log(data);
     let release = {};
     release.country = 'XW';
     release.packaging = 'None';
@@ -112,16 +111,13 @@ function parseRelease(data) {
         let artists = [];
         let featured_artists = [];
         $.each(performers, function(index, performer) {
-            console.log(performer);
             if ($.inArray('featured', performer[1]) != -1) {
                 featured_artists.push(performer[0]);
             } else if ($.inArray('artist', performer[1]) != -1 || $.inArray('Main Artist', performer[1]) != -1) {
                 artists.push(performer[0]);
             }
         });
-        console.log(artists);
         track.artist_credit = MBImport.makeArtistCredits(artists);
-        console.log(track.artist_credit);
         if (featured_artists.length) {
             if (track.artist_credit.length) {
                 track.artist_credit[track.artist_credit.length - 1].joinphrase = ' feat. ';
@@ -194,7 +190,6 @@ function sendReplacement(data) {
     if (this.onreadystatechange) {
         this._onreadystatechange = this.onreadystatechange;
     }
-    // console.log(this);
     this.onreadystatechange = onReadyStateChangeReplacement;
     return send.apply(this, arguments);
 }

--- a/spotify_importer.user.js
+++ b/spotify_importer.user.js
@@ -58,10 +58,13 @@ function parseRelease(data) {
 
     release.url = data.external_urls.spotify;
     release.barcode = data.external_ids.upc;
-    release.type = data.type;
-    if (typeof data.album_type !== 'undefined') {
+
+    if (data.album_type == 'compilation') {
+        release.type = 'album';
         release.secondary_types = [];
         release.secondary_types.push(data.album_type);
+    } else {
+        release.type = data.album_type;
     }
 
     release.urls = [];


### PR DESCRIPTION
This piggybacks on the official web-player's API requests to parse information.
This script is based on the qobuz_importer I modified some time ago.

From my testing, it seems the Spotify data is a bit crappy. There are
release dates that belong to the original releases. All the performers
seem to be 'artist', so featured and classical releases need cleaning when
importing. No language info.
The API limit seems to be 50 tracks - not tested.