### PR TITLE
 MusicBrainz: Add recording edit links to instrument pages 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 -   [MusicBrainz: Set recording comments for a release](#set-recording-comments)
 -   [Musicbrainz DiscIds Detector](#mb_discids_detector)
 -   [Musicbrainz UI enhancements](#mb_ui_enhancements)
+-   [MusicBrainz: Add recording edit links to instrument pages](#edit-instrument-recordings-links)
 
 ## <a name="mb_relationship_shortcuts"></a> Display shortcut for relationships on MusicBrainz
 
@@ -176,3 +177,10 @@ Various UI enhancements for Musicbrainz
 
 [![Source](https://github.com/jerone/UserScripts/blob/master/_resources/Source-button.png)](https://github.com/murdos/musicbrainz-userscripts/blob/master/mb_ui_enhancements.user.js)
 [![Install](https://raw.github.com/jerone/UserScripts/master/_resources/Install-button.png)](https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/mb_ui_enhancements.user.js)
+
+## <a name="edit-instrument-recordings-links"></a> MusicBrainz: Add recording edit links to instrument pages
+
+Direct links to the recording edit page are added to instruments' recordings pages.
+
+[![Source](https://github.com/jerone/UserScripts/blob/master/_resources/Source-button.png)](https://github.com/murdos/musicbrainz-userscripts/blob/master/edit-instrument-recordings-links.user.js)
+[![Install](https://raw.github.com/jerone/UserScripts/master/_resources/Install-button.png)](https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/edit-instrument-recordings-links.user.js)

--- a/edit-instrument-recordings-links.user.js
+++ b/edit-instrument-recordings-links.user.js
@@ -1,0 +1,59 @@
+// ==UserScript==
+// @name		MusicBrainz: Add recording edit links to instrument pages
+// @description Direct links to the recording edit page are added to instruments' recordings pages.
+// @version		2019.4.2.1
+// @author		Nicolás Tamargo
+// @license     X11
+// @downloadURL https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/edit-instrument-recordings-links.user.js
+// @updateURL   https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/edit-instrument-recordings-links.user.js
+// @include     *://musicbrainz.org/instrument/*/recordings*
+// @include     *://*.musicbrainz.org/instrument/*/recordings*
+// @grant       none
+// ==/UserScript==
+
+// ==License==
+// Copyright (C) 2019 Nicolás Tamargo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// Except as contained in this notice, the name(s) of the above copyright
+// holders shall not be used in advertising or otherwise to promote the sale,
+// use or other dealings in this Software without prior written
+// authorization.
+// ==/License==
+//**************************************************************************//
+
+// There should be only one of each
+const table = document.getElementsByClassName('tbl')[0];
+const header = table.getElementsByTagName('thead')[0].getElementsByTagName('tr')[0];
+const recordings = table.getElementsByTagName('tbody')[0].getElementsByTagName('tr');
+
+// We add a column to the header to make it less ugly
+const headerColumn = document.createElement('th');
+headerColumn.innerText = 'Edit';
+header.appendChild(headerColumn);
+
+// We add the links to the recordings
+for (let i = 0; i < recordings.length; i++) {
+    const recordingRow = recordings[i];
+    const recordingUrl = recordingRow.childNodes[3].childNodes[0].getAttribute('href');
+    const extraCell = document.createElement('td');
+    extraCell.innerHTML = `<a href="${recordingUrl}/edit">edit</a>`;
+    recordingRow.appendChild(extraCell);
+}


### PR DESCRIPTION
Tiny userscript that was requested for instrument cleanup and might help people who want to quickly edit recordings to set a better instrument (e.g. after a new instrument is added that previously was only entered as an instrument credit).
