### PR TITLE
New checkbox to “Make all edits votable.” like in all MBS edit pages

### DIFF
--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           MusicBrainz: Set recording comments for a release
 // @description    Batch set recording comments from a Release page.
-// @version        2018.2.18.1
+// @version        2019.5.10.1
 // @author         Michael Wiencek
 // @license        X11
 // @namespace      790382e7-8714-47a7-bfbd-528d0caa2333
@@ -136,6 +136,14 @@ function setRecordingComments() {
     <td><textarea id="recording-comments-edit-note" style="width: 32em;" rows="5"></textarea></td>\
   </tr>\
   <tr>\
+    <td colspan="2" class="auto-editor">\
+      <label>\
+        <input id="make-recording-comments-votable" type="checkbox">\
+        Make all edits votable.\
+      </label>\
+    </td>\
+  </tr>\
+  <tr>\
     <td colspan="2">\
       <button id="submit-recording-comments" class="styled-button">Submit changes (visible and marked red)</button>\
     </td>\
@@ -199,12 +207,13 @@ function setRecordingComments() {
             $submitButton.prop('disabled', false).text('Submit changes (marked red)');
         } else {
             let editNote = $('#recording-comments-edit-note').val();
+            let makeVotable = document.getElementById('make-recording-comments-votable').checked;
 
             activeRequest = $.ajax({
                 type: 'POST',
                 url: '/ws/js/edit/create',
                 dataType: 'json',
-                data: JSON.stringify({ edits: editData, editNote: editNote }),
+                data: JSON.stringify({ edits: editData, editNote: editNote, makeVotable: makeVotable }),
                 contentType: 'application/json; charset=utf-8'
             })
                 .always(function() {


### PR DESCRIPTION
This is very needed when I want to keep my edits open at the same time of concurrent merges, for instance.
If merge edits are voted down or cancelled, recording comment edits can be cancelled accordingly or voted down at the same time.

![image](https://user-images.githubusercontent.com/1401086/57531282-594c1800-7339-11e9-8381-be6ceb542e17.png)

- https://musicbrainz.org/edit/61162453#note-61162453-2
- https://musicbrainz.org/search/edits?auto_edit_filter=&order=desc&negation=0&combinator=and&conditions.0.field=release&conditions.0.operator=%3D&conditions.0.name=Popmart%3A+Live+from+Mexico+City&conditions.0.args.0=813469&conditions.2.field=type&conditions.2.operator=%3D&conditions.2.args=204%2C72%2C245&conditions.2.args=74&conditions.3.field=editor&conditions.3.operator=%3D&conditions.3.name=jesus2099&conditions.3.args.0=285909