### PR TITLE
mb_relationship_shortcuts: Fix width of subheaders

### DIFF
--- a/mb_relationship_shortcuts.user.js
+++ b/mb_relationship_shortcuts.user.js
@@ -117,14 +117,16 @@ $(document).ready(function() {
     });
 
     // Adapt width of subheader rows by incrementing the colspan of a cell
-    $("table.tbl tr.subh").each(function() {
-        $(this).children("th[colspan]").attr('colspan', function(index, oldValue) {
-            if (index === 0) {
-                return Number(oldValue) + 1;
-            } else {
-                return oldValue;
-            }
-        });
+    $('table.tbl tr.subh').each(function() {
+        $(this)
+            .children('th[colspan]')
+            .attr('colspan', function(index, oldValue) {
+                if (index === 0) {
+                    return Number(oldValue) + 1;
+                } else {
+                    return oldValue;
+                }
+            });
     });
 
     // Calculate offset for multi-page lists

--- a/mb_relationship_shortcuts.user.js
+++ b/mb_relationship_shortcuts.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           Display shortcut for relationships on MusicBrainz
 // @description    Display icon shortcut for relationships of release-group, release, recording and work: e.g. Amazon, Discogs, Wikipedia, ... links. This allows to access some relationships without opening the entity page.
-// @version        2018.2.18.1
+// @version        2020.3.31.1
 // @author         Aurelien Mino <aurelien.mino@gmail.com>
 // @licence        GPL (http://www.gnu.org/copyleft/gpl.html)
 // @downloadURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/mb_relationship_shortcuts.user.js
@@ -114,6 +114,17 @@ $(document).ready(function() {
                     return false;
                 }
             });
+    });
+
+    // Adapt width of subheader rows by incrementing the colspan of a cell
+    $("table.tbl tr.subh").each(function() {
+        $(this).children("th[colspan]").attr('colspan', function(index, oldValue) {
+            if (index === 0) {
+                return Number(oldValue) + 1;
+            } else {
+                return oldValue;
+            }
+        });
     });
 
     // Calculate offset for multi-page lists


### PR DESCRIPTION
This adapts the width of all subheader rows in the release table on release group pages. Usually there is a single `th`-Element with a `colspan` of 7, which now has to span the additional *Relationships* column that is inserted by this script.
In case the server code changes, only the `colspan` of the first `th` cell is incremented.

**Before:**
![mb_relationship_shortcuts user js before](https://user-images.githubusercontent.com/52860029/78014840-ca792d00-7348-11ea-8e28-b4c1e2f4de98.png)

**After:**
![mb_relationship_shortcuts user js after](https://user-images.githubusercontent.com/52860029/78014911-debd2a00-7348-11ea-8b63-fc1df219435f.png)