### PR TITLE
bandcamp_importer: Make UPC a link to Atisket.

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -358,6 +358,6 @@ $(document).ready(function() {
     $('div#bci_link a').css({ 'font-weight': 'bold' });
     let upc = unsafeWindow.TralbumData.current.upc;
     if (typeof upc != 'undefined' && upc !== null) {
-        $('div #trackInfoInner').append(`<div id="mbimport_upc" style="margin-bottom: 2em; font-size: smaller;">UPC: ${upc}</div>`);
+        $('div #trackInfoInner').append(`<div id="mbimport_upc" style="margin-bottom: 2em; font-size: smaller;">UPC: <a href="https://etc.marlonob.info/atisket/?upc=${upc}">${upc}</a></div>`);
     }
 });


### PR DESCRIPTION
It's often useful to look up the UPC to make sure it's actually a digital release. Make that process easier.