### PR TITLE
Fix use of undefined release.discs[discindex]

### DIFF
--- a/discogs_importer.user.js
+++ b/discogs_importer.user.js
@@ -703,7 +703,7 @@ function parseDiscogsRelease(data) {
 
         // Create release if needed
         let discindex = releaseNumber - 1;
-        if (!release.discs[discindex]) {
+        while (!release.discs[discindex]) {
             let newdisc = {
                 tracks: [],
                 format: release_formats[discindex],


### PR DESCRIPTION
Opening https://www.discogs.com/Ryuichi-Sakamoto-Year-Book-1985-1989/release/11652104
gives a problem because undefined (release.discs[discindex]) doesn't have
a format member in line 721
`release.discs[discindex].format.match(/(Vinyl|Cassette)/) ...`

This fixes the problem (it leaves the medium empty and stores its tracks
in the previous medium, but at least it doesn't break the script).