### PR TITLE
Add 'recording' mbid param to release seeder

### DIFF
--- a/lib/mbimport.js
+++ b/lib/mbimport.js
@@ -223,7 +223,8 @@ var MBImport = (function () {
                     total_duration += duration_ms;
                 }
                 appendParameter(parameters, `mediums.${i}.track.${j}.length`, tracklength);
-
+                appendParameter(parameters, `mediums.${i}.track.${j}.recording`,
+                    track.recording ? track.recording : '');
                 buildArtistCreditsFormParameters(parameters, `mediums.${i}.track.${j}.`, track.artist_credit);
             }
         }

--- a/lib/mbimport.js
+++ b/lib/mbimport.js
@@ -223,8 +223,7 @@ var MBImport = (function () {
                     total_duration += duration_ms;
                 }
                 appendParameter(parameters, `mediums.${i}.track.${j}.length`, tracklength);
-                appendParameter(parameters, `mediums.${i}.track.${j}.recording`,
-                    track.recording ? track.recording : '');
+                appendParameter(parameters, `mediums.${i}.track.${j}.recording`, track.recording);
                 buildArtistCreditsFormParameters(parameters, `mediums.${i}.track.${j}.`, track.artist_credit);
             }
         }


### PR DESCRIPTION
Adding the Parameter "mediums.x.track.y.recording" defined in https://musicbrainz.org/doc/Development/Release_Editor_Seeding

Not sure if this should be documented since it's an optional parameter. I just needed it for https://github.com/loujine/musicbrainz-scripts/blob/master/mb-edit-create_release_from_recording.user.js where I knew the preexisting recording MBID