### PR TITLE
Bandcamp: set barcode if digital only

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           Import Bandcamp releases to MusicBrainz
 // @description    Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version        2020.6.8.1
+// @version        2020.9.1.1
 // @namespace      http://userscripts.org/users/22504
 // @downloadURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL      https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
@@ -200,9 +200,11 @@ var BandcampImport = {
             });
         }
 
-        // Check if release has a barcode defined
+        // UPCs generally apply to physical releases so set the barcode when
+        // digital download is the only available medium
+        let mediums = bandcampAlbumData.packages;
         let upc = bandcampAlbumData.current.upc;
-        if (upc !== null) {
+        if ((mediums === null || mediums.length === 0) && upc !== null) {
             release.barcode = upc;
         }
 


### PR DESCRIPTION
Most UPCs on Bandcamp apply to physical releases and there appears to be no way to determine whether a UPC also applies to the digital version. This PR updates the logic to set the barcode when digital download is the only available release.

Example where UPC refers to physical release:

https://gatedrecordings.bandcamp.com/album/in-the-key-of-g

Example where UPC refers to digital release:

https://isophene.bandcamp.com/album/echo-point