### PR TITLE
Replace Lodash by built-in ES6 methods

### DIFF
--- a/batch-add-recording-relationships.user.js
+++ b/batch-add-recording-relationships.user.js
@@ -39,7 +39,7 @@
 // authorization.
 // ==/License==
 
-var scr = document.createElement('script');
+const scr = document.createElement('script');
 scr.textContent = `(${batch_recording_rels})();`;
 document.body.appendChild(scr);
 
@@ -393,7 +393,7 @@ function batch_recording_rels() {
                 .on('change', function () {
                     setting(`work_${kind}`, this.value);
                 });
-    });
+        });
     });
 
     $('<span></span>').append('<img src="/static/images/icons/loading.gif"/> ', $recordings_load_msg).insertBefore($relate_table);
@@ -627,7 +627,7 @@ function batch_recording_rels() {
         //Use the dates in "live YYYY-MM-DD" disambiguation comments
 
         let comment = node.disambiguation;
-        let date = comment && comment.match && comment.match(/live(?: .+)?, ([0-9]{4}(?:-[0-9]{2}(?:-[0-9]{2})?)?)(?:\: .+)?$/);
+        let date = comment && comment.match && comment.match(/live(?: .+)?, ([0-9]{4}(?:-[0-9]{2}(?:-[0-9]{2})?)?)(?:: .+)?$/);
         if (date) {
             $attrs.find('input.date').val(date[1]).trigger('input');
         }
@@ -638,7 +638,7 @@ function batch_recording_rels() {
             } else {
                 let url = `/ws/2/recording/${node.id}?inc=releases+release-groups&fmt=json`;
 
-                var request_rec = function () {
+                const request_rec = function () {
                     $.get(url, function (data) {
                         let releases = data.releases;
 
@@ -860,7 +860,7 @@ function batch_recording_rels() {
                 }
             };
 
-            var iid = setInterval(function () {
+            const iid = setInterval(function () {
                 let j = current++;
                 let norm_work_title = norm_titles[j];
                 let score = sim(rec_title, norm_work_title);

--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           MusicBrainz: Set recording comments for a release
 // @description    Batch set recording comments from a Release page.
-// @version        2019.5.10.1
+// @version        2020.9.12.1
 // @author         Michael Wiencek
 // @license        X11
 // @namespace      790382e7-8714-47a7-bfbd-528d0caa2333
@@ -80,7 +80,11 @@ function setRecordingComments() {
         let release = location.pathname.match(MBID_REGEX)[0];
 
         $.get(`/ws/2/release/${release}?inc=recordings&fmt=json`, function (data) {
-            let comments = _.map(_.map(_.flatten(_.map(data.media, 'tracks')), 'recording'), 'disambiguation');
+            let comments = Array.from(data.media)
+                .map(medium => medium.tracks)
+                .flat()
+                .map(track => track.recording)
+                .map(recording => recording.disambiguation);
 
             for (let i = 0, len = comments.length; i < len; i++) {
                 let comment = comments[i];

--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -41,7 +41,7 @@
 // authorization.
 // ==/License==
 
-var scr = document.createElement('script');
+const scr = document.createElement('script');
 scr.textContent = `$(${setRecordingComments});`;
 document.body.appendChild(scr);
 
@@ -56,7 +56,7 @@ function setRecordingComments() {
         )
     );
 
-    var delay = setInterval(function () {
+    const delay = setInterval(function () {
         $tracks = $('.medium tbody tr[id]');
 
         if ($tracks.length) {
@@ -97,8 +97,8 @@ function setRecordingComments() {
         return;
     }
 
-    var MBID_REGEX = /[a-f\d]{8}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{12}/,
-        editing = false,
+    const MBID_REGEX = /[a-f\d]{8}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{12}/;
+    let editing = false,
         activeRequest = null;
 
     $('body').on('input.rc', '.recording-comment', function () {
@@ -152,7 +152,7 @@ function setRecordingComments() {
         $inputs.filter(':visible').val(this.value).trigger('input.rc');
     });
 
-    var $submitButton = $('#submit-recording-comments').on('click', function () {
+    const $submitButton = $('#submit-recording-comments').on('click', function () {
         if (activeRequest) {
             activeRequest.abort();
             activeRequest = null;


### PR DESCRIPTION
Lodash has been dropped from MBS and this breaks some userscripts that rely on it.
I've replaced all occurences of `_` (Lodash) with the equivalent methods of `Array` and `Object`.

Fixes #299