### PR TITLE
Add VGMdb import script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 -   [Import Naxos Music Library releases to MusicBrainz](#naxos_library_importer)
 -   [Import Qobuz releases to MusicBrainz](#qobuz_importer)
 -   [Import Takealot releases to MusicBrainz](#takealot_importer)
+-   [Import VGMdb releases into MusicBrainz](#vgmdb_importer)
 -   [MusicBrainz: 1200px CAA](#mb_1200px_caa)
 -   [MusicBrainz: Add recording edit links to instrument pages](#edit-instrument-recordings-links)
 -   [MusicBrainz: Batch-add "performance of" relationships](#batch-add-recording-relationships)
@@ -159,6 +160,13 @@ Add a button to import https://www.takealot.com/ releases to MusicBrainz via API
 
 [![Source](https://github.com/jerone/UserScripts/blob/master/_resources/Source-button.png)](https://github.com/murdos/musicbrainz-userscripts/blob/master/takealot_importer.user.js)
 [![Install](https://raw.github.com/jerone/UserScripts/master/_resources/Install-button.png)](https://raw.github.com/murdos/musicbrainz-userscripts/master/takealot_importer.user.js)
+
+## <a name="vgmdb_importer"></a> Import VGMdb releases into MusicBrainz
+
+One-click importing of releases from vgmdb.net into MusicBrainz
+
+[![Source](https://github.com/jerone/UserScripts/blob/master/_resources/Source-button.png)](https://github.com/murdos/musicbrainz-userscripts/blob/master/vgmdb_importer.user.js)
+[![Install](https://raw.github.com/jerone/UserScripts/master/_resources/Install-button.png)](https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/vgmdb_importer.user.js)
 
 ## <a name="mb_1200px_caa"></a> MusicBrainz: 1200px CAA
 

--- a/vgmdb_importer.user.js
+++ b/vgmdb_importer.user.js
@@ -37,13 +37,13 @@ function parseApi(apiResponse) {
     const release = {
         title: apiDict.name,
         artist_credit: [],
-        labels: [],
         urls: [],
         discs: [],
         status: mapStatus(apiDict.publish_format),
         year: releaseDate.year,
         month: releaseDate.month,
         day: releaseDate.day,
+        labels: [{ name: mapLabel(apiDict.organizations), catno: apiDict.catalog }],
     };
 
     return release;
@@ -98,4 +98,32 @@ function mapDate(releaseDate) {
     const d = new Date(releaseDate);
 
     return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDay() };
+}
+
+/*
+ * Returns a likely label based on a list of VGMdb organizations.
+ */
+function mapLabel(organizations) {
+    const labelOrganization = getLabelOrganization(organizations);
+    if (labelOrganization) {
+        return labelOrganization['names']['en'];
+    } else if (organizations.length == 1) {
+        // If only one, assume that's the one
+        return organizations[0]['names']['en'];
+    } else {
+        return null;
+    }
+}
+
+/*
+ * Returns an organization element with the "label" role, or null if none exists.
+ */
+function getLabelOrganization(organizations) {
+    for (const organization of organizations) {
+        if (organization['role'] === 'label') {
+            return organization;
+        }
+    }
+
+    return null;
 }

--- a/vgmdb_importer.user.js
+++ b/vgmdb_importer.user.js
@@ -11,4 +11,56 @@
 // @require        lib/logger.js
 // @require        lib/mbimportstyle.js
 // @icon           https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png
+// @grant          GM.xmlHttpRequest
 // ==/UserScript==
+
+$(document).ready(function () {
+    MBImportStyle();
+    MBSearchItStyle();
+
+    let apiUrl = window.location.href.replace('net', 'info').concat('', '?format=json');
+
+    GM.xmlHttpRequest({
+        method: 'GET',
+        url: apiUrl,
+        onload: function (resp) {
+            const release = parseApi(resp.responseText);
+            insertButtons(release);
+        },
+    });
+});
+
+function parseApi(apiResponse) {
+    const apiDict = JSON.parse(apiResponse);
+    const release = {
+        title: apiDict.name,
+        artist_credit: [],
+        labels: [],
+        urls: [],
+        discs: [],
+    };
+
+    return release;
+}
+
+function insertButtons(release) {
+    const editNote = MBImport.makeEditNote(window.location.href, 'VGMdb');
+    console.log(editNote);
+    const parameters = MBImport.buildFormParameters(release, editNote);
+    const formHtml = $(MBImport.buildFormHTML(parameters)).attr('style', 'margin: 5px 0 0 5px; display: inline-block').prop('outerHTML');
+    const linkHtml = $(MBImport.buildSearchButton(release)).attr('style', 'margin: 5px 0 0 5px; display: inline-block').prop('outerHTML');
+
+    const vgmdbHtml =
+        '<div style="width: 250px; background-color: #1B273D">' +
+        '<b class="rtop"><b></b></b>' +
+        '<div style="padding: 6px 10px 0px 10px">' +
+        '<h3>MusicBrainz</h3>' +
+        '</div>' +
+        '</div>' +
+        `<div style="width: 250px; background-color: #2F364F;">${formHtml}${linkHtml}` +
+        '<b class="rbot"><b></b></b> ' +
+        '</div>' +
+        '<br style="clear: left" />';
+
+    $('#rightcolumn').prepend(vgmdbHtml);
+}

--- a/vgmdb_importer.user.js
+++ b/vgmdb_importer.user.js
@@ -182,7 +182,31 @@ function mapDiscs(vgmdbDiscs, mediaFormat) {
  * Returns a MusicBrainz format based on a VGMdb media format.
  */
 function mapFormat(mediaFormat) {
-    return mediaFormat;
+    switch (mediaFormat) {
+        case 'Flexi Disc':
+            return 'Vinyl';
+        case 'Digital':
+        case 'Download Card':
+            return 'Digital Media';
+        case 'SA-CD':
+            return 'SACD';
+        case 'CD Video':
+            return 'CDV';
+        case 'Laser Disc':
+            return 'LaserDisc';
+        case 'Floppy Disc':
+            return 'Other';
+        case 'USB':
+            return 'USB Flash Drive';
+        case 'UHQCD':
+        case 'Blu-spec CD':
+        case 'Blu-spec CD2':
+        case 'HQCD':
+        case 'SHM-CD':
+            return 'CD';
+        default:
+            return mediaFormat;
+    }
 }
 
 /*

--- a/vgmdb_importer.user.js
+++ b/vgmdb_importer.user.js
@@ -1,0 +1,14 @@
+// ==UserScript==
+// @name           Import VGMdb releases into MusicBrainz
+// @namespace      https://github.com/murdos/musicbrainz-userscripts/
+// @description    One-click importing of releases from vgmdb.net into MusicBrainz
+// @version        2020.9.26.1
+// @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/vgmdb_importer.user.js
+// @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/vgmdb_importer.user.js
+// @include        /^https://vgmdb.net/(album|artist|org)/\d+
+// @require        https://code.jquery.com/jquery-3.5.1.min.js
+// @require        lib/mbimport.js
+// @require        lib/logger.js
+// @require        lib/mbimportstyle.js
+// @icon           https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png
+// ==/UserScript==

--- a/vgmdb_importer.user.js
+++ b/vgmdb_importer.user.js
@@ -42,6 +42,7 @@ function parseApi(apiResponse) {
         month: releaseDate.month,
         day: releaseDate.day,
         labels: [{ name: mapLabel(apiDict.organizations), catno: apiDict.catalog }],
+        barcode: apiDict.barcode,
         urls: mapUrls(apiDict.vgmdb_link, apiDict.stores, apiDict.websites),
         discs: mapDiscs(apiDict.discs, apiDict.media_format),
     };

--- a/vgmdb_importer.user.js
+++ b/vgmdb_importer.user.js
@@ -161,7 +161,6 @@ function mapDiscs(vgmdbDiscs, mediaFormat) {
 
     for (const vgmdbDisc of vgmdbDiscs) {
         const disc = {};
-        disc['title'] = vgmdbDisc['name'];
 
         if (multipleMedia) {
             const discMediaFormat = extractVgmdbMedia(vgmdbDisc['name']);

--- a/vgmdb_importer.user.js
+++ b/vgmdb_importer.user.js
@@ -38,6 +38,7 @@ function parseApi(apiResponse) {
         labels: [],
         urls: [],
         discs: [],
+        status: mapStatus(apiDict.publish_format),
     };
 
     return release;
@@ -63,4 +64,24 @@ function insertButtons(release) {
         '<br style="clear: left" />';
 
     $('#rightcolumn').prepend(vgmdbHtml);
+}
+
+/*
+ * Returns MusicBrainz status based on VGMdb publish_format.
+ *
+ * MusicBrainz: official, promotion, bootleg, pseudo
+ * VGMdb, comma separated:
+ *   * one of Commercial, Doujin/Indie, Bootleg
+ *   * one of Limited Edition, Enclosure, First Press Bonus, Preorder Bonus,
+ *     Retailer Bonus, Event Only, Promo/Gift/Reward, Rental (General does not appear in API)
+ */
+function mapStatus(publishFormat) {
+    if (publishFormat.includes('Bootleg')) {
+        // Overrides promo
+        return 'bootleg';
+    } else if (publishFormat.includes('Promo/Gift/Reward')) {
+        return 'promotion';
+    } else {
+        return 'official';
+    }
 }

--- a/vgmdb_importer.user.js
+++ b/vgmdb_importer.user.js
@@ -32,6 +32,8 @@ $(document).ready(function () {
 
 function parseApi(apiResponse) {
     const apiDict = JSON.parse(apiResponse);
+    const releaseDate = mapDate(apiDict.release_date);
+
     const release = {
         title: apiDict.name,
         artist_credit: [],
@@ -39,6 +41,9 @@ function parseApi(apiResponse) {
         urls: [],
         discs: [],
         status: mapStatus(apiDict.publish_format),
+        year: releaseDate.year,
+        month: releaseDate.month,
+        day: releaseDate.day,
     };
 
     return release;
@@ -84,4 +89,13 @@ function mapStatus(publishFormat) {
     } else {
         return 'official';
     }
+}
+
+/*
+ * Returns year, month and day dict based on ISO 8601 date string.
+ */
+function mapDate(releaseDate) {
+    const d = new Date(releaseDate);
+
+    return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDay() };
 }


### PR DESCRIPTION
Adds an import script using the VGMdb.info API. Works for the most part, but could of course be further refined. Fixes #81.