### PR TITLE
Add support for release annotation field in mbimport

### DIFF
--- a/lib/mbimport.js
+++ b/lib/mbimport.js
@@ -183,6 +183,9 @@ var MBImport = (function () {
         // Disambiguation comment
         appendParameter(parameters, 'comment', release.comment);
 
+        // Annotation
+        appendParameter(parameters, 'annotation', release.annotation);
+
         // Label + catnos
         for (let i = 0; i < release.labels.length; i++) {
             let label = release.labels[i];


### PR DESCRIPTION
I intend to use the annotation field in a future importer script to store release metadata from the importing website (idagio). Add support for it