### PR TITLE
Make the 'Edit recording comments' button appear again

### DIFF
--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           MusicBrainz: Set recording comments for a release
 // @description    Batch set recording comments from a Release page.
-// @version        2020.9.12.1
+// @version        2021.8.5.1
 // @author         Michael Wiencek
 // @license        X11
 // @namespace      790382e7-8714-47a7-bfbd-528d0caa2333
@@ -12,6 +12,7 @@
 // @exclude        *musicbrainz.org/release/*/*
 // @exclude        *.mbsandbox.org/release/*/*
 // @grant          none
+// @run-at         document-idle
 // ==/UserScript==
 
 // ==License==


### PR DESCRIPTION
The script will now run after the page and all resources are loaded and page scripts have run. This will be later than before and (hopefully) after any React redraws which undid the DOM changes done by the script.

Tested and working with Violentmonkey under Firefox, for Tampermonkey document-idle is the default value anyway.

See https://community.metabrainz.org/t/541943 where the problem has also been reported and where I will ask for some additional test users with different browser / userscript manager setups.