### PR TITLE
mb_discids_detector: Fix regex pattern for title/artists.

### DIFF
--- a/mb_discids_detector.user.js
+++ b/mb_discids_detector.user.js
@@ -91,7 +91,7 @@ function gazellePageHandler() {
 
     // Determine Artist name and Release title
     let titleAndArtists = $('#content div.thin h2:eq(0)').text();
-    let pattern = /(.*) - (.*) \[.*\] \[.*/;
+    let pattern = /(.*) [-–] (.*) \[.*\] \[.*/;
     let artistName, releaseName;
     if ((m = titleAndArtists.match(pattern))) {
         artistName = m[1];


### PR DESCRIPTION
At least one Gazelle site recently changed from using a regular hyphen to an en dash. Update the regex to include this character.