### PR TITLE
CSS for the line break in the "Import into MB" button in deezer.com

### DIFF
--- a/lib/mbimportstyle.js
+++ b/lib/mbimportstyle.js
@@ -34,6 +34,9 @@ function MBImportStyle() {
     min-height: 16px;
     display: inline-block;
   }
+  img[src*="musicbrainz.org"] {
+    display: inline-block;
+  }
   `;
     _add_css(css_import_button);
 }


### PR DESCRIPTION
Apparently it was an issue only noticeable in deezer.com:


Before the style
![2021-09-22-08-03-53-screenshot](https://user-images.githubusercontent.com/89880718/134333086-1f278004-9bce-4557-9167-7a8a00dc0133.png)

After the style
![2021-09-22-08-05-33-screenshot](https://user-images.githubusercontent.com/89880718/134333126-3673f246-ec40-4b74-aee4-9a4b038492ff.png)

