### PR TITLE
hdtracks: Make the userscript run under Greasemonkey

### DIFF
--- a/hdtracks_importer.user.js
+++ b/hdtracks_importer.user.js
@@ -2,7 +2,7 @@
 // @name           Import HDtracks releases into MusicBrainz
 // @namespace      https://github.com/murdos/musicbrainz-userscripts/
 // @description    One-click importing of releases from hdtracks.com into MusicBrainz. Also allows to submit their ISRCs to MusicBrainz releases.
-// @version        2021.10.17.2
+// @version        2021.11.7.1
 // @author         kellnerd
 // @license        MIT
 // @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/hdtracks_importer.user.js
@@ -20,7 +20,7 @@ this.$ = this.jQuery = jQuery.noConflict(true);
 
 $(document).ready(function () {
     MBImportStyle();
-    window.onhashchange = parsePage; // HDtracks is a single page app (SPA)
+    window.addEventListener('hashchange', parsePage); // HDtracks is a single page app (SPA)
 });
 
 async function parsePage() {


### PR DESCRIPTION
GM has no direct access to the properties of the real `window`, call the `addEventListener` method instead (which is also a cleaner solution).
The script is now also running under GM 4.11 (and still works with Violentmonkey).