### PR TITLE
expand-rg: Stretch tracklist tables to the full column width

### DIFF
--- a/expand-collapse-release-groups.user.js
+++ b/expand-collapse-release-groups.user.js
@@ -3,7 +3,7 @@
 // @description	  See what's inside a release group without having to follow its URL. Also adds convenient edit links for it.
 // @namespace     http://userscripts.org/users/266906
 // @author        Michael Wiencek <mwtuea@gmail.com>
-// @version       2020.8.1.1
+// @version       2021.12.10
 // @license       GPL
 // @downloadURL   https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/expand-collapse-release-groups.user.js
 // @updateURL     https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/expand-collapse-release-groups.user.js
@@ -78,16 +78,15 @@ function inject_release_group_button(parent) {
 function inject_release_button(parent, _table_parent, _table, _mbid) {
     let mbid = _mbid || parent.querySelector('a').href.match(MBID_REGEX),
         table = _table || document.createElement('table');
+    let table_parent = _table_parent || parent; // fallback for pages where we do not inject the release groups
 
-    table.style.marginTop = '1em';
-    table.style.marginLeft = '1em';
     table.style.paddingLeft = '1em';
 
     let button = create_button(
         `/ws/2/release/${mbid}?inc=media+recordings+artist-credits&fmt=json`,
         function (toggled) {
-            if (toggled) parent.appendChild(table);
-            else parent.removeChild(table);
+            if (toggled) table_parent.appendChild(table);
+            else table_parent.removeChild(table);
         },
         function (json) {
             parse_release(json, table);

--- a/expand-collapse-release-groups.user.js
+++ b/expand-collapse-release-groups.user.js
@@ -3,7 +3,7 @@
 // @description	  See what's inside a release group without having to follow its URL. Also adds convenient edit links for it.
 // @namespace     http://userscripts.org/users/266906
 // @author        Michael Wiencek <mwtuea@gmail.com>
-// @version       2021.12.10
+// @version       2021.12.10.1
 // @license       GPL
 // @downloadURL   https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/expand-collapse-release-groups.user.js
 // @updateURL     https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/expand-collapse-release-groups.user.js
@@ -65,7 +65,7 @@ function inject_release_group_button(parent) {
             else parent.removeChild(table);
         },
         function (json) {
-            parse_release_group(json, mbid, parent, table);
+            parse_release_group(json, mbid, table);
         },
         function (status) {
             table.innerHTML = `<tr><td style="color: #f00;">Error loading release group (HTTP status ${status})</td></tr>`;
@@ -159,7 +159,7 @@ function format_time(ms) {
     return `${Math.floor(ts / 60)}:${s >= 10 ? s : `0${s}`}`;
 }
 
-function parse_release_group(json, mbid, parent, table) {
+function parse_release_group(json, mbid, table) {
     let releases = json.releases;
     table.innerHTML = '';
 

--- a/expand-collapse-release-groups.user.js
+++ b/expand-collapse-release-groups.user.js
@@ -40,13 +40,13 @@
 const MBID_REGEX = /[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}/;
 
 const releasesOrReleaseGroups = document.querySelectorAll("#content table.tbl > tbody > tr > td a[href^='/release']");
-for (let r = 0; r < releasesOrReleaseGroups.length; r++) {
-    let entityLink = releasesOrReleaseGroups[r].getAttribute('href');
+for (const entity of releasesOrReleaseGroups) {
+    const entityLink = entity.getAttribute('href');
     if (entityLink.match(/\/release-group\//)) {
-        inject_release_group_button(releasesOrReleaseGroups[r].parentNode);
+        inject_release_group_button(entity.parentNode);
     } else if (!entityLink.match(/\/cover-art/)) {
         // avoid injecting a second button for a release's cover art link
-        inject_release_button(releasesOrReleaseGroups[r].parentNode);
+        inject_release_button(entity.parentNode);
     }
 }
 
@@ -163,17 +163,17 @@ function parse_release_group(json, mbid, parent, table) {
     let releases = json.releases;
     table.innerHTML = '';
 
-    for (let i = 0; i < releases.length; i++) {
-        let release = releases[i],
-            media = {},
+    for (const release of releases) {
+        let media = {},
             tracks = [],
             formats = [];
 
-        for (let j = 0; j < release.media.length; j++) {
-            let medium = release.media[j],
-                format = medium.format,
+        for (const medium of release.media) {
+            let format = medium.format,
                 count = medium['track-count'];
-            if (format) format in media ? (media[format] += 1) : (media[format] = 1);
+            if (format) {
+                format in media ? (media[format] += 1) : (media[format] = 1);
+            }
             tracks.push(count);
         }
 
@@ -193,36 +193,35 @@ function parse_release_group(json, mbid, parent, table) {
         return 0;
     });
 
-    for (let i = 0; i < releases.length; i++) {
-        (function (release) {
-            let track_tr = document.createElement('tr'),
-                track_td = document.createElement('td'),
-                track_table = document.createElement('table'),
-                format_td = document.createElement('td'),
-                tr = document.createElement('tr'),
-                td = document.createElement('td'),
-                a = createLink(`/release/${release.id}`, release.title);
+    for (const release of releases) {
+        let track_tr = document.createElement('tr'),
+            track_td = document.createElement('td'),
+            track_table = document.createElement('table'),
+            format_td = document.createElement('td'),
+            tr = document.createElement('tr'),
+            td = document.createElement('td'),
+            a = createLink(`/release/${release.id}`, release.title);
 
-            track_td.colSpan = 6;
-            track_table.style.width = '100%';
-            track_table.style.marginLeft = '1em';
-            track_tr.appendChild(track_td);
-            inject_release_button(td, track_td, track_table, release.id);
-            td.appendChild(a);
-            if (release.disambiguation) {
-                td.appendChild(document.createTextNode(` (${release.disambiguation})`));
-            }
-            tr.appendChild(td);
-            format_td.innerHTML = release.formats;
-            tr.appendChild(format_td);
+        track_td.colSpan = 6;
+        track_table.style.width = '100%';
+        track_table.style.marginLeft = '1em';
+        track_tr.appendChild(track_td);
+        inject_release_button(td, track_td, track_table, release.id);
+        td.appendChild(a);
+        if (release.disambiguation) {
+            td.appendChild(document.createTextNode(` (${release.disambiguation})`));
+        }
+        tr.appendChild(td);
+        format_td.innerHTML = release.formats;
+        tr.appendChild(format_td);
 
-            let columns = [release.tracks, release.date || '', release.country || '', release.status || ''];
+        let columns = [release.tracks, release.date || '', release.country || '', release.status || ''];
+        for (const column of columns) {
+            tr.appendChild(createElement('td', column));
+        }
 
-            for (let i = 0; i < columns.length; i++) tr.appendChild(createElement('td', columns[i]));
-
-            table.appendChild(tr);
-            table.appendChild(track_tr);
-        })(releases[i]);
+        table.appendChild(tr);
+        table.appendChild(track_tr);
     }
 
     let bottom_tr = document.createElement('tr'),
@@ -288,12 +287,11 @@ function parse_release(json, table) {
     table.appendChild(bottom_tr);
 }
 
-function createAC(obj) {
+function createAC(artist_credit_array) {
     let span = document.createElement('span');
 
-    for (let i = 0; i < obj.length; i++) {
-        let credit = obj[i],
-            artist = credit.artist,
+    for (const credit of artist_credit_array) {
+        let artist = credit.artist,
             link = createLink(`/artist/${artist.id}`, credit.name || artist.name);
 
         link.setAttribute('title', artist['sort-name']);

--- a/expand-collapse-release-groups.user.js
+++ b/expand-collapse-release-groups.user.js
@@ -37,10 +37,10 @@
 // @exclude       *musicbrainz.org/series/*/*
 // ==/UserScript==
 
-var MBID_REGEX = /[0-9a-z]{8}\-[0-9a-z]{4}\-[0-9a-z]{4}\-[0-9a-z]{4}\-[0-9a-z]{12}/;
+const MBID_REGEX = /[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}/;
 
-var releasesOrReleaseGroups = document.querySelectorAll("#content table.tbl > tbody > tr > td a[href^='/release']");
-for (var r = 0; r < releasesOrReleaseGroups.length; r++) {
+const releasesOrReleaseGroups = document.querySelectorAll("#content table.tbl > tbody > tr > td a[href^='/release']");
+for (let r = 0; r < releasesOrReleaseGroups.length; r++) {
     let entityLink = releasesOrReleaseGroups[r].getAttribute('href');
     if (entityLink.match(/\/release-group\//)) {
         inject_release_group_button(releasesOrReleaseGroups[r].parentNode);
@@ -163,23 +163,22 @@ function parse_release_group(json, mbid, parent, table) {
     let releases = json.releases;
     table.innerHTML = '';
 
-    for (var i = 0; i < releases.length; i++) {
+    for (let i = 0; i < releases.length; i++) {
         let release = releases[i],
             media = {},
             tracks = [],
             formats = [];
 
         for (let j = 0; j < release.media.length; j++) {
-            var medium = release.media[j],
+            let medium = release.media[j],
                 format = medium.format,
                 count = medium['track-count'];
             if (format) format in media ? (media[format] += 1) : (media[format] = 1);
             tracks.push(count);
         }
 
-        for (format in media) {
-            var count = media[format],
-                txt;
+        for (let format in media) {
+            let count = media[format];
             if (count > 1) formats.push(`${count.toString()}&#215;${format}`);
             else formats.push(format);
         }
@@ -194,7 +193,7 @@ function parse_release_group(json, mbid, parent, table) {
         return 0;
     });
 
-    for (var i = 0; i < releases.length; i++) {
+    for (let i = 0; i < releases.length; i++) {
         (function (release) {
             let track_tr = document.createElement('tr'),
                 track_td = document.createElement('td'),
@@ -256,8 +255,9 @@ function parse_release(json, table) {
             let track = medium.tracks[j],
                 recording = track.recording,
                 disambiguation = recording.disambiguation ? ` (${recording.disambiguation})` : '',
-                length = track.length ? format_time(track.length) : '?:??';
-            (artist_credit = track['artist-credit'] || track.recording['artist-credit']), (tr = document.createElement('tr'));
+                length = track.length ? format_time(track.length) : '?:??',
+                artist_credit = track['artist-credit'] || track.recording['artist-credit'],
+                tr = document.createElement('tr');
 
             tr.appendChild(createElement('td', j + 1));
             let title_td = createElement('td', disambiguation);


### PR DESCRIPTION
This gives injected tracklists more horizontal space instead of stuffing them into a sub-column of a column. The additional margin is not necessary for injected releases, only for release groups.
Reverting an undocumented change from 02f93f7 which (unintentionally?) abandoned the dedicated `track_tr` row (highlighted in the screenshots below).

<img src="https://user-images.githubusercontent.com/52860029/145601192-4bba4acd-1251-439d-9874-44d74394857c.png" width="50%" title="Before" /><img src="https://user-images.githubusercontent.com/52860029/145601273-498a5cb4-e6b6-4db7-ae79-d29a523ff4e2.png" width="50%" title="After" />

I have also fixed the remaining ESLint warnings and did some minor refactorings (replacing index loops with for-of loops where possible, removing an unused parameter) while I was already at it.