### PR TITLE
Set recording comments: Delay script and enable medium URL #399 work-around

### DIFF
--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -7,9 +7,7 @@
 // @namespace      790382e7-8714-47a7-bfbd-528d0caa2333
 // @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/set-recording-comments.user.js
 // @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/set-recording-comments.user.js
-// @match          *://*.musicbrainz.org/release/*
-// @exclude        *musicbrainz.org/release/*/*
-// @exclude        *musicbrainz.org/release/add*
+// @include        /^https?:\/\/(\w+\.)?musicbrainz\.org\/release\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}(\/disc\/\d+|$)/
 // @grant          none
 // @run-at         document-idle
 // ==/UserScript==
@@ -95,7 +93,7 @@ function setRecordingComments() {
         });
     }, 1000);
 
-    if (!location.pathname.match(/^\/release\/[a-f\d]{8}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{12}$/)) {
+    if (!location.pathname.match(/^\/release\/[a-f\d]{8}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{12}/)) {
         return;
     }
 

--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -39,10 +39,10 @@
 // authorization.
 // ==/License==
 
-setTimeout(function() {
-	const scr = document.createElement('script');
-	scr.textContent = `$(${setRecordingComments});`;
-	document.body.appendChild(scr);
+setTimeout(function () {
+    const scr = document.createElement('script');
+    scr.textContent = `$(${setRecordingComments});`;
+    document.body.appendChild(scr);
 }, 1000);
 
 function setRecordingComments() {

--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           MusicBrainz: Set recording comments for a release
 // @description    Batch set recording comments from a Release page.
-// @version        2021.8.22.1
+// @version        2022.2.3
 // @author         Michael Wiencek
 // @license        X11
 // @namespace      790382e7-8714-47a7-bfbd-528d0caa2333
@@ -41,9 +41,11 @@
 // authorization.
 // ==/License==
 
-const scr = document.createElement('script');
-scr.textContent = `$(${setRecordingComments});`;
-document.body.appendChild(scr);
+setTimeout(function() {
+	const scr = document.createElement('script');
+	scr.textContent = `$(${setRecordingComments});`;
+	document.body.appendChild(scr);
+}, 1000);
 
 function setRecordingComments() {
     let $tracks;


### PR DESCRIPTION
A very rough fix, `document-idle` dda9dcb6c14b7ac5ccafd2e1572180b7a281fd19 was eventually not enough for me, 9 times of 10, React still removes the button!

~~It does not fix #399, except if you quickly Expand all mediums, before the second elapses. ;)~~
<ins>I have added [ulugabi work-around](https://community.metabrainz.org/t/script-set-recording-comments-user-js/541943/10?u=jesus2099) for #399: Enable `/disc/123` (medium) URL.</ins>

For #399, it needs to delay the loading to the last moment, when the user clicks the button.
But I have no time for this, at the moment.

