### PR TITLE
SVG MB logo, more HTTPS + small changes

### DIFF
--- a/lib/mbimport.js
+++ b/lib/mbimport.js
@@ -63,7 +63,7 @@
 var MBImport = (function () {
     // --------------------------------------- publics ----------------------------------------- //
 
-    let special_artists = {
+    const special_artists = {
         various_artists: {
             name: 'Various Artists',
             mbid: '89ad4ac3-39f7-470e-963a-56509c546377',
@@ -74,7 +74,7 @@ var MBImport = (function () {
         },
     };
 
-    let url_types = {
+    const url_types = {
         purchase_for_download: 74,
         download_for_free: 75,
         discogs: 76,
@@ -85,14 +85,13 @@ var MBImport = (function () {
     };
 
     function fnSpecialArtist(key, ac) {
-        let credited_name = '';
         let joinphrase = '';
         if (typeof ac !== 'undefined') {
             joinphrase = ac.joinphrase;
         }
         return {
             artist_name: special_artists[key].name,
-            credited_name: credited_name,
+            credited_name: '',
             joinphrase: joinphrase,
             mbid: special_artists[key].mbid,
         };
@@ -106,13 +105,13 @@ var MBImport = (function () {
             let value = `${parameter.value}`;
             url_params.push(encodeURI(`${parameter.name}=${value}`));
         });
-        return `<a class="musicbrainz_import" href="//musicbrainz.org/search?${url_params.join('&')}">Search in MusicBrainz</a>`;
+        return `<a class="musicbrainz_import" href="https://musicbrainz.org/search?${url_params.join('&')}">Search in MusicBrainz</a>`;
     }
 
     // compute HTML of search button
     function fnBuildSearchButton(release) {
         let parameters = searchParams(release);
-        let html = `<form class="musicbrainz_import musicbrainz_import_search" action="//musicbrainz.org/search" method="get" target="_blank" accept-charset="UTF-8" charset="${document.characterSet}">`;
+        let html = `<form class="musicbrainz_import musicbrainz_import_search" action="https://musicbrainz.org/search" method="get" target="_blank" accept-charset="UTF-8" charset="${document.characterSet}">`;
         parameters.forEach(function (parameter) {
             let value = `${parameter.value}`;
             html += `<input type='hidden' value='${value.replace(/'/g, '&apos;')}' name='${parameter.name}'/>`;
@@ -126,20 +125,20 @@ var MBImport = (function () {
         type = type.replace('-', '_');
 
         let params = [`query=${luceneEscape(what)}`, `type=${type}`, 'indexed=1'];
-        return `//musicbrainz.org/search?${params.join('&')}`;
+        return `https://musicbrainz.org/search?${params.join('&')}`;
     }
 
     // compute HTML of import form
     function fnBuildFormHTML(parameters) {
         // Build form
-        let innerHTML = `<form class="musicbrainz_import musicbrainz_import_add" action="//musicbrainz.org/release/add" method="post" target="_blank" accept-charset="UTF-8" charset="${document.characterSet}">`;
+        let innerHTML = `<form class="musicbrainz_import musicbrainz_import_add" action="https://musicbrainz.org/release/add" method="post" target="_blank" accept-charset="UTF-8" charset="${document.characterSet}">`;
         parameters.forEach(function (parameter) {
             let value = `${parameter.value}`;
             innerHTML += `<input type='hidden' value='${value.replace(/'/g, '&apos;')}' name='${parameter.name}'/>`;
         });
 
         innerHTML +=
-            '<button type="submit" title="Import this release into MusicBrainz (open a new tab)"><img src="//musicbrainz.org/favicon.ico" /><span>Import into MB</span></button>';
+            '<button type="submit" title="Import this release into MusicBrainz (open a new tab)"><img src="https://raw.githubusercontent.com/metabrainz/design-system/master/brand/logos/MusicBrainz/SVG/MusicBrainz_logo_icon.svg" width="16" height="16" /><span>Import into MB</span></button>';
         innerHTML += '</form>';
 
         return innerHTML;

--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -63,7 +63,7 @@ var MBLinks = function (user_cache_key, version, expiration) {
     let cache_version = 2;
     this.user_cache_key = user_cache_key;
     this.cache_key = `${this.user_cache_key}-v${cache_version}${typeof version != 'undefined' ? `.${version}` : ''}`;
-    this.mb_server = '//musicbrainz.org';
+    this.mb_server = 'https://musicbrainz.org';
     // overrides link title and img src url (per type), see createMusicBrainzLink()
     this.type_link_info = {
         release_group: {


### PR DESCRIPTION
Noticed the MB logo doesn't look so nice, e.g. on https://heilung.bandcamp.com/album/drif:

![image](https://user-images.githubusercontent.com/2644614/178605887-1b303255-87b5-4a16-9a6a-fc1b4a977c2c.png)

I've tried hard to find the logo somewhere hosted on https://musicbrainz.org/, but haven't succeeded.
@zas, maybe you know? :)

So for now the new URL is not as nice:
https://raw.githubusercontent.com/metabrainz/design-system/master/brand/logos/MusicBrainz/SVG/MusicBrainz_logo_icon.svg
But as you probably guess from the URL, it's from the official design system here: https://github.com/metabrainz/design-system/blob/master/brand/logos/MusicBrainz/SVG/MusicBrainz_logo_icon.svg

And now it looks nice:

![image](https://user-images.githubusercontent.com/2644614/178608559-4dccb68a-5c29-4a0b-a1bd-3b3ded342177.png)

Additionally did a bit of stuff around.

In case you are wondering why I removed the protocol-relative URLs:
https://www.paulirish.com/2010/the-protocol-relative-url/

> Now that SSL is [encouraged for everyone](https://www.eff.org/encrypt-the-web-report) and [doesn't have performance concerns](https://istlsfastyet.com/), **this technique is now an anti-pattern**. If the asset you need is available on SSL, then **always** use the `https://` asset.

Please test thoroughly before merging as I haven't 🙏