### PR TITLE
added code to display 'mbid' on sidebar

### DIFF
--- a/mb_ui_enhancements.user.js
+++ b/mb_ui_enhancements.user.js
@@ -73,9 +73,16 @@ $(document).ready(function () {
         'i'
     );
     if (window.location.href.match(re)) {
-        $("#sidebar h2:contains('Release information')").before($("#sidebar h2:contains('Release information')"));
-        var mbid = window.location.href.match(re)[2];
-        $("#sidebar h2:contains('Release information')").before(`<h2 class="mbid">MBID</h2><p>${mbid}<p>`);
+        if ($("#sidebar h2:contains('Release information')").length > 0 ) {
+          $("#sidebar h2:contains('Release information')").before($("#sidebar h2:contains('Release information')"));
+          var mbid = window.location.href.match(re)[2];
+          $("#sidebar h2:contains('Release information')").before(`<h2 class="mbid">MBID</h2><p>${mbid}<p>`);
+        }
+        else if ($("#sidebar h2:contains('Recording information')").length > 0) {
+          $("#sidebar h2:contains('Recording information')").before($("#sidebar h2:contains('Recording information')"));
+          var mbid = window.location.href.match(re)[2];
+          $("#sidebar h2:contains('Recording information')").before(`<h2 class="mbid">MBID</h2><p>${mbid}<p>`);
+        }
     }
 
     // Better fix for http://tickets.musicbrainz.org/browse/MBS-1943

--- a/mb_ui_enhancements.user.js
+++ b/mb_ui_enhancements.user.js
@@ -67,6 +67,17 @@ $(document).ready(function () {
         }
     }
 
+    // Display 'mbid' on sidebar
+    re = new RegExp(
+        'musicbrainz.org/(release|recording)/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})',
+        'i'
+    );
+    if (window.location.href.match(re)) {
+        $("#sidebar h2:contains('Release information')").before($("#sidebar h2:contains('Release information')"));
+        var mbid = window.location.href.match(re)[2];
+        $("#sidebar h2:contains('Release information')").before(`<h2 class="mbid">MBID</h2><p>${mbid}<p>`);
+    }
+
     // Better fix for http://tickets.musicbrainz.org/browse/MBS-1943
     re = new RegExp(
         'musicbrainz.org/(artist|release-group|release|recording|work|label)/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})',

--- a/mb_ui_enhancements.user.js
+++ b/mb_ui_enhancements.user.js
@@ -74,12 +74,10 @@ $(document).ready(function () {
     );
     if (window.location.href.match(re)) {
         if ($("#sidebar h2:contains('Release information')").length > 0 ) {
-          $("#sidebar h2:contains('Release information')").before($("#sidebar h2:contains('Release information')"));
           var mbid = window.location.href.match(re)[2];
           $("#sidebar h2:contains('Release information')").before(`<h2 class="mbid">MBID</h2><p>${mbid}<p>`);
         }
         else if ($("#sidebar h2:contains('Recording information')").length > 0) {
-          $("#sidebar h2:contains('Recording information')").before($("#sidebar h2:contains('Recording information')"));
           var mbid = window.location.href.match(re)[2];
           $("#sidebar h2:contains('Recording information')").before(`<h2 class="mbid">MBID</h2><p>${mbid}<p>`);
         }


### PR DESCRIPTION
I wanted an easy way to copy and paste just the MBID as needed for external uses. 
On release & recording pages, this will show a 'MBID' field in the sidebar, with just the mbid value for easy copy & paste
This is easier than copying a portion of the URL every time (some programs do accept full url).