### PR TITLE
beatport_importer: Add UPC and ISRC support

### DIFF
--- a/beatport_importer.user.js
+++ b/beatport_importer.user.js
@@ -28,7 +28,7 @@ $(document).ready(function () {
         let release_url = window.location.href.replace('/?.*$/', '').replace(/#.*$/, '');
         let release = retrieveReleaseInfo(release_url, release_data);
 
-        const track_urls = release_data.tracks.map(url => url.replace('api.beatport.com', 'www.beatport.com/api')).replace(/\/$/, '');
+        const track_urls = release_data.tracks.map(url => url.replace('api.beatport.com', 'www.beatport.com/api').replace(/\/$/, ''));
         let results = [];
         const promises = track_urls.map((url, index) => $.getJSON(url).then(response => (results[index] = response)));
 

--- a/beatport_importer.user.js
+++ b/beatport_importer.user.js
@@ -28,12 +28,12 @@ $(document).ready(function () {
         let release_url = window.location.href.replace('/?.*$/', '').replace(/#.*$/, '');
         let release = retrieveReleaseInfo(release_url, release_data);
 
-        const track_urls = release_data.tracks.map(url => url.replace('api.beatport.com', 'www.beatport.com/api')).reverse();
+        const track_urls = release_data.tracks.map(url => url.replace('api.beatport.com', 'www.beatport.com/api'));
         let results = [];
         const promises = track_urls.map((url, index) => $.getJSON(url).then(response => (results[index] = response)));
 
         Promise.all(promises)
-            .then(() => results.map(result => result.isrc))
+            .then(() => results.map(({ isrc, number }) => ({ isrc, number })))
             .then(isrcs => {
                 insertLink(release, release_url, isrcs);
             });
@@ -147,7 +147,7 @@ function insertLink(release, release_url, isrcs) {
         '<form class="musicbrainz_import"><button type="submit" title="Submit ISRCs to MusicBrainz with kepstin’s MagicISRC"><span>Submit ISRCs</span></button></form>'
     )
         .on('click', event => {
-            const query = isrcs.map((isrc, index) => (isrc == null ? `isrc${index + 1}=` : `isrc${index + 1}=${isrc}`)).join('&');
+            const query = isrcs.map(({ isrc, number }) => (isrc == null ? `isrc${number}=` : `isrc${number}=${isrc}`)).join('&');
             event.preventDefault();
             window.open(`https://magicisrc.kepstin.ca?${query}`);
         })

--- a/beatport_importer.user.js
+++ b/beatport_importer.user.js
@@ -24,12 +24,14 @@ if (!unsafeWindow) unsafeWindow = window;
 $(document).ready(function () {
     MBImportStyle();
 
-    let release_url = window.location.href.replace('/?.*$/', '').replace(/#.*$/, '');
-    let release = retrieveReleaseInfo(release_url);
-    insertLink(release, release_url);
+    $.getJSON(`https://www.beatport.com/api/v4/catalog/releases/${ProductDetail.id}`).done(data => {
+        let release_url = window.location.href.replace('/?.*$/', '').replace(/#.*$/, '');
+        let release = retrieveReleaseInfo(release_url, data);
+        insertLink(release, release_url);
+    });
 });
 
-function retrieveReleaseInfo(release_url) {
+function retrieveReleaseInfo(release_url, release_data) {
     let releaseDate = ProductDetail.date.published.split('-');
 
     // Release information global to all Beatport releases
@@ -48,6 +50,7 @@ function retrieveReleaseInfo(release_url) {
         type: '',
         urls: [],
         labels: [],
+        barcode: release_data.upc,
         discs: [],
     };
 

--- a/beatport_importer.user.js
+++ b/beatport_importer.user.js
@@ -3,7 +3,7 @@
 // @author         VxJasonxV
 // @namespace      https://github.com/murdos/musicbrainz-userscripts/
 // @description    One-click importing of releases from beatport.com/release pages into MusicBrainz
-// @version        2019.12.21.1
+// @version        2023.6.30.1
 // @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_importer.user.js
 // @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_importer.user.js
 // @include        http://www.beatport.com/release/*

--- a/beatport_importer.user.js
+++ b/beatport_importer.user.js
@@ -28,7 +28,7 @@ $(document).ready(function () {
         let release_url = window.location.href.replace('/?.*$/', '').replace(/#.*$/, '');
         let release = retrieveReleaseInfo(release_url, release_data);
 
-        const track_urls = release_data.tracks.map(url => url.replace('api.beatport.com', 'www.beatport.com/api'));
+        const track_urls = release_data.tracks.map(url => url.replace('api.beatport.com', 'www.beatport.com/api')).replace(/\/$/, '');
         let results = [];
         const promises = track_urls.map((url, index) => $.getJSON(url).then(response => (results[index] = response)));
 


### PR DESCRIPTION
This PR adds registration feature of UPC and ISRC on beatport_importer.user.js by using the Beatport API and [kepstin's MagicISRC](https://magicisrc.kepstin.ca/).