### PR TITLE
beatport_importer: Adapt to website changes

### DIFF
--- a/beatport_importer.user.js
+++ b/beatport_importer.user.js
@@ -152,5 +152,6 @@ function insertLink(mbrelease, release_url, isrcs) {
     $('div[title="Collection controls"]').append(mbUI);
     $('form.musicbrainz_import').css({ display: 'inline-block', 'margin-left': '5px' });
     $('form.musicbrainz_import button').css({ width: '120px' });
+    $('form.musicbrainz_import button img').css({ display: 'inline-block' });
     mbUI.slideDown();
 }

--- a/beatport_importer.user.js
+++ b/beatport_importer.user.js
@@ -3,7 +3,7 @@
 // @author         VxJasonxV
 // @namespace      https://github.com/murdos/musicbrainz-userscripts/
 // @description    One-click importing of releases from beatport.com/release pages into MusicBrainz
-// @version        2023.6.30.1
+// @version        2023.7.22.1
 // @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_importer.user.js
 // @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_importer.user.js
 // @include        http://www.beatport.com/release/*


### PR DESCRIPTION
Beatport website has been updated recently, and the userscript no longer work at all. This PR adapts to these changes, but several problems still remain.

* The new API does not provide track numbers, so there are concerns about whether imported tracks are in the correct order.
* The API is called every 100 tracks, so for a release with more than 100 tracks like [this](https://www.beatport.com/release/a-state-of-trance-1000-celebration-mix-mixed-by-armin-van-buuren-extended-versions/3277362), import will not work properly.