### PR TITLE
Discogs: minor updates

### DIFF
--- a/discogs_importer.user.js
+++ b/discogs_importer.user.js
@@ -266,6 +266,8 @@ function insertMBLinks(current_page_key) {
     } else if (current_page_info.type === 'master') {
         // master release artist
         add_mblinks($root, 'h1', ['artist']);
+        // master release tracklist
+        add_mblinks($root, 'table[class^=tracklist_] td[class^=artist_]', ['artist']);
         setInterval(() => {
             // dynamically expanded credits section (master release summary)
             add_mblinks($root, '#Credits li[class^=artist_]', ['artist']);

--- a/discogs_importer.user.js
+++ b/discogs_importer.user.js
@@ -261,7 +261,7 @@ function insertMBLinks(current_page_key) {
             // dynamically loaded and paged (master) release listing
             add_mblinks($root, 'table[class^=labelReleasesTable_]', ['artist', 'master', 'release']);
             // dynamically expanded master release
-            add_mblinks($root, 'tr[class^=versionsTextWithCoversRow_', ['artist', 'release']);
+            add_mblinks($root, 'tr[class^=versionsTextWithCoversRow_]', ['artist', 'release']);
         }, 1500);
     } else if (current_page_info.type === 'master') {
         // master release artist

--- a/discogs_importer.user.js
+++ b/discogs_importer.user.js
@@ -2,7 +2,7 @@
 
 // @name           Import Discogs releases to MusicBrainz
 // @description    Add a button to import Discogs releases to MusicBrainz and add links to matching MusicBrainz entities for various Discogs entities (artist,release,master,label)
-// @version        2024.02.4.1
+// @version        2024.03.28.1
 // @namespace      http://userscripts.org/users/22504
 // @downloadURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/discogs_importer.user.js
 // @updateURL      https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/discogs_importer.user.js


### PR DESCRIPTION
This PR fixes a typo in a selector and adds a new selector for artists on VA master release pages.