### PR TITLE
bandcamp_importer: Harmony link auto-checks other services

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -408,7 +408,7 @@ $(document).ready(function () {
         document.querySelector('div #trackInfoInner').insertAdjacentHTML(
             'beforeend',
             `<div id="mbimport_upc" style="margin-bottom: 2em; font-size: smaller;">UPC: ${upc}<br/>
-            Import: <a href="https://harmony.pulsewidth.org.uk/release?url=${encodeURIComponent(release.url)}">Harmony</a>
+            Import: <a href="https://harmony.pulsewidth.org.uk/release?url=${encodeURIComponent(release.url)}&deezer=&itunes=&spotify=&tidal=&beatport">Harmony</a>
             | <a href="https://atisket.pulsewidth.org.uk/?upc=${upc}">a-tisket</a></div>`
         );
     }


### PR DESCRIPTION
Makes the Harmony link auto-search/check the other available platforms in Harmony, saving 5 clicks every time.

I'm not sure why anybody clicking this link would not want those fields checked, if they are only interested in BC data they can use this Bandcamp importer script to import.