### PR TITLE
DO NOT MERGE. Qobuz fixes and page source scraping

### DIFF
--- a/lib/mbimport.js
+++ b/lib/mbimport.js
@@ -2,7 +2,7 @@
 //                                          MusicBrainz Import helper functions
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-/*
+/**
  * How to use this module?
  *
  * - First build a release object (see expected format below) that you'll fill in from source of data
@@ -10,10 +10,58 @@
  *     var parameters = MBImport.buildFormParameters(parsedRelease, optionalEditNote);
  * - Then build the HTML that you'll inject into source site page:
  *     var formHtml = MBImport.buildFormHTML(parameters);
- * - Addinionally, you can inject a search link to verify that the release is not already known by MusicBrainz:
+ * - Additionally, you can inject a search link to verify that the release is not already known by MusicBrainz:
  *     var linkHtml = MBImport.buildSearchLink(parsedRelease);
  *
- * Expected format of release object:
+ * Expected format of the release object:
+ *
+ * @typedef {Object} Release
+ * @property {string} title - The title of the release
+ * @property {ArtistCredit[]} artist_credit - The artist credits for the release
+ * @property {string} type - The type of the release (album, single, EP, etc.)
+ * @property {string} status - The status of the release (official, promotional, bootleg, etc.)
+ * @property {string[]} secondary_types - The secondary types of the release (live, remix, etc.)
+ * @property {string} language - The language of the release (English, French, etc.)
+ * @property {string} script - The script of the release (Latin, Cyrillic, etc.)
+ * @property {string} packaging - The packaging of the release (jewel case, digipak, etc.)
+ * @property {string[]} country - The countries of the release (US, UK, etc.)
+ * @property {number} year - The year of the release
+ * @property {number} month - The month of the release
+ * @property {number} day - The day of the release
+ * @property {Label[]} labels - The labels of the release
+ * @property {string} barcode - The barcode of the release
+ * @property {string} comment - The comment for the release
+ * @property {string} annotation - The annotation for the release
+ * @property {ReleaseURL[]} urls - The URLs associated with the release
+ * @property {Disc[]} discs - The discs of the release
+ * @property {string} [release_group_mbid] - The MusicBrainz ID of the release group
+ *
+ * @typedef {Object} Label
+ * @property {string} name - The name of the label
+ * @property {string} mbid - The MusicBrainz ID of the label
+ * @property {string} catno - The catalog number of the label
+ *
+ * @typedef {Object} ArtistCredit
+ * @property {string} credited_name - The name as it appears on the release
+ * @property {string} artist_name - The name of the artist
+ * @property {string} mbid - The MusicBrainz ID of the artist
+ * @property {string} joinphrase - The join phrase between artists
+ *
+ * @typedef {Object} ReleaseURL
+ * @property {string} url - A URL associated with the release
+ * @property {string} link_type - The type of this link (purchase for download, download for free, etc.)
+ *
+ * @typedef {Object} Disc
+ * @property {string} title - The title of the disc
+ * @property {string} format - The format of the disc (CD, vinyl, etc.)
+ * @property {PlayerTrack[]} tracks - The tracks on the disc
+ *
+ * @typedef {Object} Track
+ * @property {string} number - The track number
+ * @property {string} title - The title of the track
+ * @property {string} duration - MM:SS or HH:MM:SS
+ * @property {string} recording - The MusicBrainz ID of the recording
+ * @property {ArtistCredit[]} artist_credit - The artist credits for the track
  *
  *     release = {
  *         title,
@@ -63,6 +111,21 @@
 const MBImport = (function () {
     // --------------------------------------- publics ----------------------------------------- //
 
+    /**
+     * @typedef {Object} SpecialArtist
+     * @property {SpecialArtistName} name
+     * @property {string} mbid - Special MusicBrainz ID of the special artist
+     *
+     * @typedef {('various_artists' | 'unknown')} SpecialArtistKey
+     * @typedef {('Various Artists' | '[unknown]')} SpecialArtistName
+     *
+     * @typedef {Record<SpecialArtistKey, SpecialArtist>} SpecialArtistMap
+     */
+
+    /**
+     * Special artists
+     * @type {SpecialArtistMap}
+     */
     const special_artists = {
         various_artists: {
             name: 'Various Artists',
@@ -74,6 +137,9 @@ const MBImport = (function () {
         },
     };
 
+    /**
+     * @type {Record<string, number>}
+     */
     const url_types = {
         purchase_for_download: 74,
         download_for_free: 75,
@@ -82,8 +148,14 @@ const MBImport = (function () {
         other_databases: 82,
         stream_for_free: 85,
         license: 301,
+        streaming: 980,
     };
 
+    /**
+     * @param {SpecialArtistKey} key
+     * @param {ArtistCredit} ac
+     * @returns {ArtistCredit}
+     */
     function fnSpecialArtist(key, ac) {
         let joinphrase = '';
         if (typeof ac !== 'undefined') {
@@ -97,7 +169,11 @@ const MBImport = (function () {
         };
     }
 
-    // compute HTML of search link
+    /**
+     * Computes the search link HTML (not used)
+     * @param {Release} release - The release object
+     * @return {string} - The HTML for the search link
+     */
     function fnBuildSearchLink(release) {
         let parameters = searchParams(release);
         let url_params = [];
@@ -108,7 +184,11 @@ const MBImport = (function () {
         return `<a class="musicbrainz_import" href="https://musicbrainz.org/search?${url_params.join('&')}">Search in MusicBrainz</a>`;
     }
 
-    // compute HTML of search button
+    /**
+     * Computes the search button HTML
+     * @param {Release} release - The release object
+     * @return {string} - The HTML for the search button
+     */
     function fnBuildSearchButton(release) {
         let parameters = searchParams(release);
         let html = `<form class="musicbrainz_import musicbrainz_import_search" action="https://musicbrainz.org/search" method="get" target="_blank" accept-charset="UTF-8" charset="${document.characterSet}">`;
@@ -128,7 +208,11 @@ const MBImport = (function () {
         return `https://musicbrainz.org/search?${params.join('&')}`;
     }
 
-    // compute HTML of import form
+    /**
+     * Computes the import form HTML
+     * @param {Array} parameters - The form parameters
+     * @return {string} - The HTML for the import form
+     */
     function fnBuildFormHTML(parameters) {
         // Build form
         let innerHTML = `<form class="musicbrainz_import musicbrainz_import_add" action="https://musicbrainz.org/release/add" method="post" target="_blank" accept-charset="UTF-8" charset="${document.characterSet}">`;
@@ -144,10 +228,15 @@ const MBImport = (function () {
         return innerHTML;
     }
 
-    // build form POST parameters that MB is waiting
+    /**
+     * Build the form POST parameters that MB expects
+     * @param {Release} release - The release object
+     * @param {string} edit_note - The edit note for the release
+     * @return {Array} - The form parameters for the release
+     */
     function fnBuildFormParameters(release, edit_note) {
         // Form parameters
-        let parameters = new Array();
+        let parameters = [];
         appendParameter(parameters, 'name', release.title);
 
         // Release Artist credits
@@ -168,13 +257,13 @@ const MBImport = (function () {
 
         // Date + country
         appendParameter(parameters, 'country', release.country);
-        if (!isNaN(release.year) && release.year != 0) {
+        if (!isNaN(release.year) && release.year !== 0) {
             appendParameter(parameters, 'date.year', release.year);
         }
-        if (!isNaN(release.month) && release.month != 0) {
+        if (!isNaN(release.month) && release.month !== 0) {
             appendParameter(parameters, 'date.month', release.month);
         }
-        if (!isNaN(release.day) && release.day != 0) {
+        if (!isNaN(release.day) && release.day !== 0) {
             appendParameter(parameters, 'date.day', release.day);
         }
 
@@ -193,7 +282,7 @@ const MBImport = (function () {
                 let label = release.labels[i];
                 appendParameter(parameters, `labels.${i}.name`, label.name);
                 appendParameter(parameters, `labels.${i}.mbid`, label.mbid);
-                if (label.catno != 'none') {
+                if (label.catno !== 'none') {
                     appendParameter(parameters, `labels.${i}.catalog_number`, label.catno);
                 }
             }
@@ -237,7 +326,7 @@ const MBImport = (function () {
         }
 
         // Guess release type if not given
-        if (!release.type && release.title && total_tracks == total_tracks_with_duration) {
+        if (!release.type && release.title && total_tracks === total_tracks_with_duration) {
             release.type = fnGuessReleaseType(release.title, total_tracks, total_duration);
         }
         appendParameter(parameters, 'type', release.type);
@@ -248,7 +337,11 @@ const MBImport = (function () {
         return parameters;
     }
 
-    // Convert a list of artists to a list of artist credits with joinphrases
+    /**
+     * Converts a list of artists to a list of artist credits with join phrases
+     * @param {string[]} artists_list - List of artists
+     * @return {ArtistCredit[]} - List of artist credits with join phrases
+     */
     function fnArtistCredits(artists_list) {
         let artists = artists_list.map(function (item) {
             return { artist_name: item };
@@ -263,7 +356,7 @@ const MBImport = (function () {
             }
             artists.push(prev);
             artists.push(last);
-        } else if (artists.length == 2) {
+        } else if (artists.length === 2) {
             artists[0].joinphrase = ' & ';
         }
         let credits = [];

--- a/qobuz_importer.user.js
+++ b/qobuz_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Qobuz releases to MusicBrainz
 // @description  Add a button on Qobuz's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2019.03.26.0
+// @version      2025.05.11.0
 // @namespace    https://github.com/murdos/musicbrainz-userscripts
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/qobuz_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/qobuz_importer.user.js
@@ -12,7 +12,7 @@
 // @require      lib/mblinks.js
 // @require      lib/mbimportstyle.js
 // @icon         https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png
-// @run-at       document-start
+// @run-at       document-idle
 // ==/UserScript==
 
 // prevent JQuery conflicts, see http://wiki.greasespot.net/@grant
@@ -28,8 +28,7 @@ if (DEBUG) {
 const various_artists_ids = [26887, 145383, 353325, 183869, 997899, 2225160],
     various_composers_ids = [573076];
 let is_classical = false, // release detected as classical
-    album_artist_data = {}, // for switching album artists on classical
-    raw_release_data;
+    album_artist_data = {}; // for switching album artists on classical
 
 function isVariousArtists(artist) {
     // Check hard-coded various artist ids
@@ -56,147 +55,317 @@ function getPerformers(trackobj) {
     );
 }
 
-function parseRelease(data) {
-    let release = {};
+/**
+ * @typedef {Object} AlbumData
+ * @property {string} [title] - The album title
+ * @property {string} [artist] - The album artist
+ * @property {string} [releaseDate] - The release date in YYYY-MM-DD format
+ * @property {string} [datePublished] - The publication date in YYYY-MM-DD format
+ * @property {string} [sku] - The Qobuz SKU (not a barcode)
+ * @property {string} [qobuzUrl] - The Qobuz URL for the album
+ * @property {string} [coverArt] - The URL for the album cover art (max size)
+ */
 
-    release.script = 'Latn';
-    release.url = `https://www.qobuz.com${data.relative_url}`; // no lang
+/**
+ * Extract album data from JSON-LD elements from the page
+ * @returns {AlbumData}
+ */
+function extractAlbumData() {
+    /**
+     * @type {AlbumData}
+     */
+    let album_data = {};
 
-    release.title = data.title;
-    if ($.inArray('Classique', data.genres_list) != -1) {
-        is_classical = true;
-        release.classical = {};
-        release.classical.discs = [];
-        album_artist_data.classical_is_various = false;
-        album_artist_data.normal_is_various = false;
-        // Use composer on classical
-        if (typeof data.composer !== 'undefined') {
-            if (isVariousArtists(data.composer)) {
-                release.classical.artist_credit = [MBImport.specialArtist('various_artists')];
-                album_artist_data.classical_is_various = true;
-            } else {
-                release.classical.artist_credit = MBImport.makeArtistCredits([data.composer.name]);
+    console.debug('Qobuz Importer: Attempting to extract embedded JSON-LD data.');
+    const script_elements = document.querySelectorAll('script[type="application/ld+json"]');
+
+    let found_product_schema = false;
+    let found_music_album_schema = false;
+
+    script_elements.forEach(script => {
+        const json_data = JSON.parse(script.textContent);
+        console.debug('Qobuz Importer: Parsing JSON-LD content:', json_data);
+
+        if (json_data['@type'] === 'Product') {
+            console.debug('Qobuz Importer: Found Product schema in JSON-LD content');
+            /**
+             * @see https://schema.org/Product
+             * @typedef {Object} ProductSchema
+             * @property {string} name - The album name.
+             * @property {string} sku - NOT a barcode, but Qobuz's own SKU.
+             * @property {BrandSchema} brand - Qobuz appears to put the album artist here.
+             * @property {string} releaseDate - In YYYY-MM-DD format.
+             * @property {string[]} image - Cover image URLs for sizes: 50x50, 200x200, 600x600.
+             *
+             * @see https://schema.org/Brand
+             * @typedef {Object} BrandSchema
+             * @property {string} name - The album artist.
+             */
+
+            /**
+             * @type {ProductSchema}
+             */
+            let product = json_data;
+
+            album_data.artist = product.brand && product.brand.name;
+            album_data.releaseDate = product.releaseDate; // TODO: this is the original release date, not the Qobuz release date
+            album_data.sku = product.sku; // This is NOT a barcode
+
+            if (product.image && Array.isArray(product.image) && product.image.length > 0) {
+                // Find the _600.jpg image or take the last one as potentially the highest resolution available
+                let coverImg = product.image.find(img => img.includes('_600.jpg')) || product.image[product.image.length - 1];
+                if (coverImg) {
+                    album_data.coverArt = coverImg.replace('_600', '_max');
+                }
             }
-        } else {
-            release.classical.artist_credit = MBImport.makeArtistCredits([data.artist.name]);
+            found_product_schema = true;
         }
-    }
 
-    if (isVariousArtists(data.artist)) {
-        release.artist_credit = [MBImport.specialArtist('various_artists')];
-        album_artist_data.normal_is_various = true;
+        if (json_data['@type'] === 'MusicAlbum') {
+            console.debug('Qobuz Importer: Found MusicAlbum schema:', json_data);
+            /**
+             * @see https://schema.org/MusicAlbum
+             * @typedef {Object} MusicAlbumSchema
+             * @property {string} name - The album name.
+             * @property {string} datePublished - The release date in YYYY-MM-DD format.
+             * @property {string} url - The Qobuz URL for the album.
+             */
+
+            /**
+             * @type {MusicAlbumSchema}
+             */
+            let music_album = json_data;
+
+            album_data.title = music_album.name;
+            album_data.datePublished = music_album.datePublished;
+
+            album_data.qobuzUrl = music_album.url;
+            // Example:  https://www.qobuz.com/us-en/album/album-name/album-id
+            let url_segments = album_data.qobuzUrl.split('/');
+            if (url_segments.length > 4) {
+                const country_and_language_segment = url_segments.splice(3, 1)[0]; // Remove the "country-language" segment
+                if (/^[a-z]{2}-[a-z]{2}$/.test(country_and_language_segment)) {
+                    // Give MusicBrainz the URL without the country-language segment.
+                    // Qobuz redirects to the user's country and language.
+                    album_data.qobuzUrl = url_segments.join('/');
+                }
+            }
+
+            found_music_album_schema = true;
+        }
+    });
+
+    if (!found_product_schema && !found_music_album_schema) {
+        console.warn('Qobuz Importer WARNING: No suitable JSON-LD Product or MusicAlbum schema found.');
     } else {
-        release.artist_credit = MBImport.makeArtistCredits([data.artist.name]);
+        console.debug('Qobuz Importer: Extracted album data from JSON-LD:', album_data);
+    }
+    return album_data;
+}
+
+/**
+ * @typedef {Object} PlayerTrack
+ * @property {string} number - The track number
+ * @property {string} title - The track title
+ * @property {string} artist - The track artist
+ * @property {string} duration - The track duration in HH:MM:SS format
+ *
+ * @typedef {Object} PlayerInfo
+ * @property {PlayerTrack[]} tracks - The album tracks
+ * @property {(string|null)} albumLabel - The album label
+ * @property {string[]} copyrights - The album copyrights
+ */
+
+/**
+ * Extract track data from the track elements in the Qobuz player on the page
+ * @returns {PlayerInfo}
+ */
+function extractPlayerInfo() {
+    console.debug('Qobuz Importer: Attempting to extract player track data.');
+
+    const player_tracks_div = document.getElementById('playerTracks');
+    if (!player_tracks_div) {
+        console.warn('Qobuz Importer WARNING: Could not find playerTracks div.');
+        return {};
     }
 
-    release.packaging = 'None';
-    release.barcode = data.upc;
-    release.country = 'XW';
-    if (i18n_global && i18n_global.zone) {
-        release.country = i18n_global.zone;
-    }
-    release.status = 'official';
-    release.urls = [];
-    release.urls.push({
-        url: release.url,
-        link_type: MBImport.URL_TYPES.purchase_for_download,
-    });
+    /**
+     * @type {PlayerTrack[]}
+     */
+    let tracks = [];
 
-    // release timestamps are using France time + daylight saving (GMT+1 or GMT+2),
-    // add 3 hours to get the day of release (matching the one displayed)
-    let releaseDate = new Date((parseInt(data.released_at, 10) + 3 * 3600) * 1000);
-    release.year = releaseDate.getUTCFullYear();
-    release.month = releaseDate.getUTCMonth() + 1;
-    release.day = releaseDate.getUTCDate();
+    let potential_labels = new Set();
+    let copyright_info = new Set();
 
-    release.labels = [];
-    $.each(data.label.name.split(' - '), function (index, label) {
-        release.labels.push({
-            name: label,
-            catno: '[none]', // no catno on qobuz ?
-        });
-    });
-    release.isrcs = [];
-    release.comment = 'Digital download';
-    release.discs = [];
-    let tracks = [],
-        classical_tracks = [],
-        old_media_num = 1;
-    $.each(data.tracks.items, function (index, trackobj) {
-        release.isrcs.push(trackobj.isrc);
-        if (trackobj.media_number != old_media_num) {
-            release.discs.push({
-                tracks: tracks,
-                format: 'Digital Media',
-            });
-            if (is_classical) {
-                release.classical.discs.push({
-                    tracks: classical_tracks,
-                    format: 'Digital Media',
-                });
-                classical_tracks = [];
-            }
-            old_media_num = trackobj.media_number;
-            tracks = [];
-        }
+    const track_elements = player_tracks_div.querySelectorAll('div.track'); // Gets all track divs
+    track_elements.forEach(element => {
+        /**
+         * @type {PlayerTrack}
+         */
         let track = {};
-        track.title = trackobj.title.replace('"', '"');
-        track.duration = trackobj.duration * 1000;
-        let performers = getPerformers(trackobj);
-        if (is_classical) {
-            let classical_artists = [];
-            if (typeof trackobj.composer !== 'undefined') {
-                classical_artists.push(trackobj.composer.name);
-            } else {
-                $.each(performers, function (index, performer) {
-                    if ($.inArray('Composer', performer[1]) != -1) {
-                        classical_artists.push(performer[0]);
+
+        track.number = element.querySelector('.track__item--number span').textContent.trim();
+        track.title = element.querySelector('.track__item--name span').textContent.trim();
+        if (element.dataset.trackV2) {
+            /**
+             * @typedef {Object} TrackV2 - "data-track-v2" in a Qobuz track element
+             * @property {string} item_name - The track name
+             * @property {string} item_brand - The track artist
+             * @property {string} item_category - The album name
+             * @property {string} item_category2 - The track label
+             */
+
+            /**
+             * @type {TrackV2}
+             */
+            let track_v2 = JSON.parse(element.dataset.trackV2); // Access data-track-v2
+
+            if (!track.title && track_v2.item_name) {
+                track.title = track_v2.item_name; // Fallback title
+            }
+            track.artist = track_v2.item_brand;
+            if (track_v2.item_category2 && track_v2.item_category2.toLowerCase() !== 'qobuz') {
+                // Avoid "Qobuz" as label
+                potential_labels.add(track_v2.item_category2.trim());
+            }
+        }
+        track.duration = element.querySelector('.track__item--duration').textContent.trim(); // HH:MM:SS
+
+        // Copyright info
+        const track_info_elements = element.querySelectorAll('.track__infos .track__info');
+        track_info_elements.forEach(track_info => {
+            const info_text = track_info.textContent.trim();
+            if (info_text.startsWith('(C)') || info_text.startsWith('(P)')) {
+                copyright_info.add(info_text);
+            }
+            // Fallback for track artist if not in data-track-v2
+            if (!track.artist && info_text.toLowerCase().includes('mainartist')) {
+                info_text.split(' - ').forEach(credit => {
+                    if (credit.toLowerCase().includes('mainartist')) {
+                        track.artist = credit.split(',')[0].trim();
                     }
                 });
             }
-            let classical_track = $.extend({}, track);
-            classical_track.artist_credit = MBImport.makeArtistCredits(classical_artists);
-            classical_tracks.push(classical_track);
-        }
-
-        let artists = [];
-        let featured_artists = [];
-        $.each(performers, function (index, performer) {
-            if ($.inArray('Featured Artist', performer[1]) != -1) {
-                featured_artists.push(performer[0]);
-            } else if (
-                // (is_classical && $.inArray('Composer', performer[1]) != -1) ||
-                $.inArray('MainArtist', performer[1]) != -1 ||
-                $.inArray('Main Performer', performer[1]) != -1 ||
-                $.inArray('Primary', performer[1]) != -1 ||
-                $.inArray('interprète', performer[1]) != -1 ||
-                $.inArray('Performer', performer[1]) != -1 ||
-                $.inArray('Main Artist', performer[1]) != -1
-            ) {
-                artists.push(performer[0]);
-            }
         });
-        track.artist_credit = MBImport.makeArtistCredits(artists);
-        if (featured_artists.length) {
-            if (track.artist_credit.length) {
-                track.artist_credit[track.artist_credit.length - 1].joinphrase = ' feat. ';
-            }
-            $.merge(track.artist_credit, MBImport.makeArtistCredits(featured_artists));
+
+        if (track.number && track.title && track.duration) {
+            tracks.push(track);
+        } else {
+            console.warn('Qobuz Importer WARNING: Missing essential data for a track:', element, track);
         }
-        tracks.push(track);
     });
-    release.discs.push({
+
+    // Determine a single album label if possible
+    let albumLabel = null;
+    if (potential_labels.size === 1) {
+        albumLabel = potential_labels.values().next().value;
+    } else if (potential_labels.size > 1) {
+        console.warn('Qobuz Importer WARNING: Multiple potential labels found:', Array.from(potential_labels));
+        // TODO: figure out the main label, or leave it for manual user input
+    }
+
+    console.debug('Qobuz Importer: Extracted tracks:', tracks);
+    console.debug('Qobuz Importer: Extracted album label:', albumLabel);
+    console.debug('Qobuz Importer: Extracted copyright info:', Array.from(copyright_info));
+
+    return {
         tracks: tracks,
-        format: 'Digital Media',
-    });
-    if (is_classical) {
-        release.classical.discs.push({
-            tracks: classical_tracks,
-            format: 'Digital Media',
+        albumLabel: albumLabel,
+        copyrights: Array.from(copyright_info), // Array of copyright strings
+    };
+}
+
+/**
+ * Parse the release data from Qobuz
+ * @param {AlbumData} album_data
+ * @param {PlayerTrack} player_info
+ * @returns {Release}
+ */
+function parseRelease(album_data, player_info) {
+    console.debug('Qobuz Importer: Parsing release info from linked data and player info');
+    console.debug('Qobuz Importer: albumInfoFromLD:', JSON.stringify(album_data, null, 2));
+    console.debug('Qobuz Importer: playerInfo:', JSON.stringify(player_info, null, 2));
+
+    /**
+     * @type {Release}
+     */
+    let release = {};
+
+    release.title = album_data.title;
+    release.artist_credit = MBImport.makeArtistCredits([album_data.artist]);
+    if (album_data.releaseDate) {
+        const [year, month, day] = album_data.releaseDate.split('-');
+        release.year = parseInt(year, 10);
+        release.month = parseInt(month, 10);
+        release.day = parseInt(day, 10);
+    }
+    release.packaging = 'None'; // Digital media, no packaging
+
+    let link_type = MBImport.URL_TYPES;
+    if (album_data.qobuzUrl) {
+        release.urls = [
+            {
+                // TODO: check whether the page allows purchase for download
+                url: album_data.qobuzUrl,
+                link_type: link_type.purchase_for_download,
+            },
+            {
+                // TODO: check whether the page allows streaming
+                url: album_data.qobuzUrl,
+                link_type: link_type.streaming,
+            },
+        ];
+    }
+
+    release.labels = [];
+    if (player_info.albumLabel) {
+        release.labels.push({
+            name: player_info.albumLabel,
+            // TODO: Where is the catalog number?
+            catno: '',
+            catalog_number: '',
         });
     }
 
-    LOGGER.info('Parsed release: ', release);
+    /**
+     * @type {Disc}
+     */
+    let disc = {
+        format: 'Digital Media',
+        tracks: [],
+    };
+    player_info.tracks.forEach(player_track => {
+        /**
+         * @type {Track}
+         */
+        let track = {
+            number: player_track.number,
+            title: player_track.title,
+            duration: player_track.duration,
+            artist_credit: MBImport.makeArtistCredits([player_track.artist]),
+        };
+        disc.tracks.push(track);
+    });
+    release.discs = [disc];
+
+    release.country = 'XW'; // Default to Worldwide - TODO: Refine to Qobuz markets?
+    release.language = 'eng'; // Default - TODO: Refine
+    release.script = 'Latn'; // Default - TODO: Refine
+    release.status = 'Official';
+    release.type = 'Album'; // TODO: add logic to infer Album, EP, Single, etc.
+
+    let commentsArray = [];
+    if (player_info.copyrights && player_info.copyrights.length > 0) {
+        commentsArray.push(...player_info.copyrights);
+    }
+    if (album_data.coverArt && album_data.coverArt.endsWith('_max.jpg')) {
+        commentsArray.push('Cover art obtained from _max.jpg URL variant.');
+    }
+    release.comment = commentsArray.join('\n').trim();
+
+    // TODO: Classical genre handling
+
+    console.debug('Qobuz Importer: Processed release object for MBImport:', JSON.stringify(release, null, 2));
     return release;
 }
 
@@ -226,9 +395,12 @@ function changeAlbumArtist() {
     album_artist_data.forced = !album_artist_data.forced;
 }
 
-// Insert button into page under label information
+/**
+ * Insert button into page under label information
+ * @param {Release} release - The release object containing all the data
+ */
 function insertLink(release) {
-    let edit_note = MBImport.makeEditNote(release.url, 'Qobuz'),
+    let edit_note = MBImport.makeEditNote(release.url, 'Qobuz', null),
         parameters = MBImport.buildFormParameters(release, edit_note),
         $album_form = $(MBImport.buildFormHTML(parameters)),
         search_form = MBImport.buildSearchButton(release);
@@ -261,12 +433,7 @@ function insertLink(release) {
         );
     }
 
-    mbUI.append(
-        $('<button id="isrcs" type="submit" title="Show list of ISRCs">Show ISRCs</button>'),
-        $(`<p><textarea id="isrclist" style="display:none">${release.isrcs.join('\n')}</textarea></p>`),
-    );
-
-    $('#info div.meta').append(mbUI);
+    $('.album-meta .album-meta__title').prepend(mbUI);
     $('form.musicbrainz_import').css({
         display: 'inline-block',
         margin: '1px',
@@ -298,43 +465,28 @@ function insertLink(release) {
     mbUI.slideDown();
 }
 
-// Hook all XMLHttpRequest to use the data fetched by the official web-player.
-(function () {
-    const send = XMLHttpRequest.prototype.send;
-    XMLHttpRequest.prototype.send = function () {
-        this.addEventListener('load', function () {
-            let wsUrl = 'https://www.qobuz.com/api.json/0.2/album/get?album_id=';
-            let repUrl = arguments[0].currentTarget.responseURL;
-            if (repUrl.startsWith(wsUrl)) {
-                raw_release_data = JSON.parse(this.responseText);
-                if (raw_release_data.status === 'error') {
-                    LOGGER.error(raw_release_data);
-                    insertErrorMessage(raw_release_data);
-                } else {
-                    let release = parseRelease(raw_release_data);
-                    insertLink(release);
-                }
-            }
-        });
-        return send.apply(this, arguments);
-    };
-})();
+// Extract data from page source
+let albumData = extractAlbumData();
+let trackData = extractPlayerInfo();
+
+if (albumData && trackData) {
+    let releaseData = parseRelease(albumData, trackData);
+    console.debug('Qobuz Importer: Release Data for MusicBrainz:', releaseData);
+    insertLink(releaseData);
+}
 
 $(document).ready(function () {
     MBImportStyle();
 
     // replace image zoom link by the maximum size image link
-    let maximgurl = $('#product-cover-link').attr('href').replace('_600', '_max');
+    let maximgurl = $('meta[property="og:image"]').attr('content').replace('_600', '_max');
     let maximg = new Image();
     maximg.onerror = function () {
         LOGGER.debug('No max image');
     };
+    console.debug('Qobuz Importer: max image URL = ', maximgurl);
     maximg.onload = function () {
-        $('#product-cover-link').attr('href', maximgurl);
-        $('#product-cover-link').attr(
-            'title',
-            `${$('#product-cover-link').attr('title')} (Qobuz importer: ${maximg.width}x${maximg.height} image)`,
-        );
+        $('div[class=modal-header]').attr('src', maximgurl);
     };
     maximg.src = maximgurl;
 });


### PR DESCRIPTION
This PR is not meant for merging into the main branch.

This is an experiment to see/show what data is available in the page source for Qobuz albums, if we were to abandon use of the undocumented API.

Using the undocumented Qobuz API is tricky and unreliable because the API auth key/token must be intercepted or scraped, and Qobuz can change it at any time. Unfortunately, the API provides some key data that does not seem to be in the page source, like the label catalog number, the Qobuz release event date, and ISRCs.

I tried to provide comments about the data that I did find in the page source and how it is structured.

Nevertheless, this patch contains some useful fixes, which might be enough for #482:
- correctly placing the MB search/submit buttons
- finding the cover art 

☝️ @jeffbyrnes

(I included type hints for `lib/mbimports.js`, although these are really just for my own use to help my IDE help me keep track of all the data elements.)
