### PR TITLE
feat(bandcamp_importer): Bandcamp importer should use batching when searching for MusicBrainz releases

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Bandcamp releases to MusicBrainz
 // @description  Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2025.04.22.1
+// @version      2025.06.01
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
@@ -305,6 +305,7 @@ $(document).ready(function () {
 
     if (isDiscographyPage) {
         const hostname = unsafeWindow.TralbumData.url.replace('/music', '');
+        const urls_data = [];
 
         $('ol#music-grid > li > a').each(function () {
             const $link = $(this);
@@ -312,17 +313,20 @@ $(document).ready(function () {
 
             if (bandcampReleaseUrl && bandcampReleaseUrl.match(/^(\/album|\/track)/)) {
                 const full_url = hostname + bandcampReleaseUrl;
-
-                mblinks.searchAndDisplayMbLink(
-                    full_url,
-                    'release',
-                    function (link) {
+                urls_data.push({
+                    url: full_url,
+                    mb_type: 'release',
+                    insert_func: function (link) {
                         $('p.title', $link).prepend(link);
                     },
-                    `release:${full_url}`,
-                );
+                    key: `release:${full_url}`,
+                });
             }
         });
+
+        if (urls_data.length > 0) {
+            mblinks.searchAndDisplayMbLinks(urls_data);
+        }
     } else {
         MBImportStyle();
 

--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -230,6 +230,93 @@ const MBLinks = function (user_cache_key, version, expiration) {
         }
     };
 
+    // Batch process multiple URLs in a single request
+    // urls_data should be an array of objects with the following structure:
+    // { url: string, mb_type: string, insert_func: function, key: string }
+    this.searchAndDisplayMbLinks = function (urls_data) {
+        let mblinks = this;
+
+        // Filter out URLs that are already cached
+        let uncached_urls = [];
+
+        urls_data.forEach(data => {
+            const key = data.key || data.url;
+            if (this.is_cached(key)) {
+                // Handle cached results immediately
+                $.each(mblinks.cache[key].urls, function (idx, mb_url) {
+                    data.insert_func(mblinks.createMusicBrainzLink(mb_url, data.mb_type.replace('-', '_')));
+                });
+            } else {
+                uncached_urls.push(data);
+            }
+        });
+
+        if (uncached_urls.length === 0) {
+            return; // All URLs were cached
+        }
+
+        // Process URLs in batches
+        const BATCH_SIZE = 75;
+        for (let i = 0; i < uncached_urls.length; i += BATCH_SIZE) {
+            const batch = uncached_urls.slice(i, i + BATCH_SIZE);
+            const resources = batch.map(data => encodeURIComponent(data.url)).join('&resource=');
+            const mb_type = batch[0].mb_type;
+            const query = `${mblinks.mb_server}/ws/2/url?resource=${resources}&inc=${mb_type}-rels`;
+
+            // Merge with previous context if there's already a pending ajax request
+            let handlers = [];
+            if (query in mblinks.ajax_requests) {
+                handlers = mblinks.ajax_requests[query].context.handlers;
+            }
+            handlers.push(function (data) {
+                if ('urls' in data) {
+                    data.urls.forEach(url_data => {
+                        const matching_url_data = batch.find(u => u.url === url_data.resource);
+                        if (matching_url_data) {
+                            const key = matching_url_data.key || matching_url_data.url;
+                            const _type = matching_url_data.mb_type.replace('-', '_');
+
+                            if (!mblinks.cache[key]) {
+                                mblinks.cache[key] = {
+                                    timestamp: new Date().getTime(),
+                                    urls: [],
+                                };
+                            }
+
+                            if ('relations' in url_data) {
+                                url_data.relations.forEach(relation => {
+                                    if (_type in relation) {
+                                        const mb_url = `${mblinks.mb_server}/${matching_url_data.mb_type}/${relation[_type].id}`;
+                                        if ($.inArray(mb_url, mblinks.cache[key].urls) === -1) {
+                                            mblinks.cache[key].urls.push(mb_url);
+                                            matching_url_data.insert_func(mblinks.createMusicBrainzLink(mb_url, _type));
+                                        }
+                                    }
+                                });
+                            }
+                        }
+                    });
+                    mblinks.saveCache();
+                }
+            });
+
+            mblinks.ajax_requests.push(
+                query,
+                function () {
+                    let ctx = this;
+                    $.getJSON(ctx.query, function (data) {
+                        ctx.handlers.forEach(handler => handler(data));
+                    });
+                },
+                {
+                    handlers: handlers,
+                    query: query,
+                    mblinks: mblinks,
+                },
+            );
+        }
+    };
+
     this.initCache();
     this.initAjaxEngine();
 


### PR DESCRIPTION
- just stumbled upon the Jira thread that release relationship lookup supports batching now;
- implemented a new function to batch process multiple URLs for MusicBrainz links;
- adjusted the existing logic to utilize the new batch processing feature for discography pages on Bandcamp.