### PR TITLE
fix: global MB buttons style issues after converting them to flexbox

### DIFF
--- a/lib/mbimport.js
+++ b/lib/mbimport.js
@@ -116,7 +116,7 @@ const MBImport = (function () {
             let value = `${parameter.value}`;
             html += `<input type='hidden' value='${value.replace(/'/g, '&apos;')}' name='${parameter.name}'/>`;
         });
-        html += '<button type="submit" title="Search for this release in MusicBrainz (open a new tab)"><span>Search in MB</span></button>';
+        html += '<button type="submit" title="Search for this release in MusicBrainz (open a new tab)">Search in MB</button>';
         html += '</form>';
         return html;
     }
@@ -138,7 +138,7 @@ const MBImport = (function () {
         });
 
         innerHTML +=
-            '<button type="submit" title="Import this release into MusicBrainz (open a new tab)"><img src="https://raw.githubusercontent.com/metabrainz/design-system/master/brand/logos/MusicBrainz/SVG/MusicBrainz_logo_icon.svg" width="16" height="16" /><span>Import into MB</span></button>';
+            '<button type="submit" title="Import this release into MusicBrainz (open a new tab)"><img src="https://raw.githubusercontent.com/metabrainz/design-system/master/brand/logos/MusicBrainz/SVG/MusicBrainz_logo_icon.svg" width="16" height="16" />Import into MB</button>';
         innerHTML += '</form>';
 
         return innerHTML;

--- a/lib/mbimportstyle.js
+++ b/lib/mbimportstyle.js
@@ -4,7 +4,12 @@ function _add_css(css) {
 
 function MBImportStyle() {
     let css_import_button = `
+    #mb_buttons {
+        display: flex;
+        gap: 5px;
+    }
   .musicbrainz_import button {
+    margin: 0 !important;
     border-radius:5px;
     display: flex;
     justify-content: center;
@@ -29,10 +34,6 @@ function MBImportStyle() {
     vertical-align: middle !important;
     margin-right: 4px !important;
     height: 16px;
-  }
-  .musicbrainz_import button span {
-    min-height: 16px;
-    display: inline-block;
   }
   img[src*="musicbrainz.org"] {
     display: inline-block;


### PR DESCRIPTION
- it turns out that there's a parent container `#mb_buttons` and that it also needs to be a flex for correctly centering the buttons;
- also makes sure we correctly centre the text inside of the buttons.

Fixes this issue that I introduced:

![image](https://github.com/user-attachments/assets/c7e5a4b2-e0db-46c5-b32f-dfb186cf97a1)