### PR TITLE
chore(bandcamp_importer,deezer): release new version to fix the import buttons

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Bandcamp releases to MusicBrainz
 // @description  Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2025.06.01
+// @version      2025.06.02
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js

--- a/deezer_importer.user.js
+++ b/deezer_importer.user.js
@@ -2,7 +2,7 @@
 // @name         Import Deezer releases into MusicBrainz
 // @namespace    https://github.com/murdos/musicbrainz-userscripts/
 // @description  One-click importing of releases from deezer.com into MusicBrainz
-// @version      2025.6.1
+// @version      2025.6.2
 // @downloadURL  https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/deezer_importer.user.js
 // @updateURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/deezer_importer.user.js
 // @include      http*://www.deezer.com/*/album/*


### PR DESCRIPTION
- and the quest continues, turns out in order for the shared code to update in an existing extesion, a new version has to be released, of which I had no idea;
- essentially, just bumping the versions of Bandcamp Importer and Deezer Importer here to make sure the fix from #634 is delivered to the users.