### PR TITLE
fix(bandcamp_importer): releases on collection-labels discography pages are failed to be linked

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Bandcamp releases to MusicBrainz
 // @description  Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2025.06.02
+// @version      2025.08.13
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
@@ -291,6 +291,27 @@ if (window.location.hostname === 'web.archive.org') {
     });
 }
 
+/**
+ * Bandcamp URLs can be relative or absolute. This function normalizes them to always be relative to the hostname.
+ */
+const getPathName = url => {
+    if (url.startsWith('/')) {
+        return url.split('?')[0].split('#')[0];
+    } else if (url.startsWith('http')) {
+        const parsed = new URL(url);
+        return parsed.pathname;
+    }
+    return null;
+};
+
+const getHostname = url => {
+    if (url.startsWith('http')) {
+        const parsed = new URL(url);
+        return `${parsed.protocol}//${parsed.hostname}`;
+    }
+    return null;
+};
+
 $(document).ready(function () {
     /* keep the following line as first, it is required to skip
      * pages which aren't actually a bandcamp page, since we support
@@ -310,9 +331,13 @@ $(document).ready(function () {
         $('ol#music-grid > li > a').each(function () {
             const $link = $(this);
             const bandcampReleaseUrl = $link.attr('href');
+            const pathName = getPathName(bandcampReleaseUrl);
 
-            if (bandcampReleaseUrl && bandcampReleaseUrl.match(/^(\/album|\/track)/)) {
-                const full_url = hostname + bandcampReleaseUrl;
+            if (pathName && pathName.match(/^(\/album|\/track)/)) {
+                const isRelative = bandcampReleaseUrl.startsWith('/');
+                const linkHostname = isRelative ? hostname : getHostname(bandcampReleaseUrl);
+                const full_url = linkHostname + pathName;
+
                 urls_data.push({
                     url: full_url,
                     mb_type: 'release',


### PR DESCRIPTION
On Bandcamp, labels can appear in at least two forms:
1. **Hosting labels** – own the releases and host them directly under the label's Bandcamp page.
2. **Collection labels** – link to releases hosted on the artist’s own Bandcamp page.

For hosting labels, discography URLs are relative and already handled correctly.  
For collection labels, discography URLs are absolute and currently fail to link correctly because:
- Some URLs include search parameters that must be stripped.
- Our hostname substitution is wrong, since the absolute URL’s hostname differs from the current page’s hostname.

**Fix:**  
- For absolute URLs, strip any search params.  
- Validate the pathname against the existing regex.  
- Rebuild the link using the original hostname from the absolute URL.

Closes #670