### PR TITLE
feat(bandcamp_importer): enhance MB link integration for stub band and label discography pages

### DIFF
--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -149,6 +149,12 @@ const MBLinks = function (user_cache_key, version, expiration) {
         }
     };
 
+    /**
+     * Create an HTML element for a MusicBrainz link with the given type and URL.
+     * @param {string} mb_url - The URL of the MusicBrainz entity.
+     * @param {string} _type - The type of the MusicBrainz entity.
+     * @returns {string} The HTML for the MusicBrainz link.
+     */
     this.createMusicBrainzLink = function (mb_url, _type) {
         let title = `See this ${_type} on MusicBrainz`;
         let img_url = `${this.mb_server}/static/images/entity/${_type}.svg`;
@@ -163,9 +169,13 @@ const MBLinks = function (user_cache_key, version, expiration) {
         return `<a href="${mb_url}" title="${title}">${img_src}</a> `;
     };
 
-    // Search for ressource 'url' on MB, for relation of type 'mb_type' (artist, release, label, release-group, ...)
-    // and call 'insert_func' function with matching MB links (a tag built in createMusicBrainzLink) for each
-    // entry found
+    /**
+     * Searches for resource 'url' on MB, for relation of type 'mb_type' (artist, release, label, release-group, ...) and calls 'insert_func' function with matching MB links (a tag built in createMusicBrainzLink) for each entry found.
+     * @param {string} url - The URL of the resource to search for.
+     * @param {string} mb_type - The type of the MusicBrainz entity.
+     * @param {function} insert_func - The function to call with the matching MB links.
+     * @param {string} [key] - The optional key to use for the cache.
+     */
     this.searchAndDisplayMbLink = function (url, mb_type, insert_func, key) {
         let mblinks = this;
         let _type = mb_type.replace('-', '_'); // underscored type


### PR DESCRIPTION
- also fixes a crash on those pages when unsafeWindow.TralbumData is  an empty object;
- if the page hasn't been linked yet, offer a discogs-style lookup;

<img width="320" height="447" alt="image" src="https://github.com/user-attachments/assets/2e939377-dfc0-4a39-8bbd-713e56e3e32b" />

<img width="320" height="447" alt="image" src="https://github.com/user-attachments/assets/f12539ca-b41f-4a9b-bee7-fd2c32710699" />

closes #676