### PR TITLE
feat(beatport_classic_importer): discontinue Beatport Classic importer script since the old service is gone

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 - [Display shortcut for relationships on MusicBrainz](#mb_relationship_shortcuts)
 - [Import Bandcamp releases to MusicBrainz](#bandcamp_importer)
 - [Import Bandcamp releases to MusicBrainz Album Link Helper](#bandcamp_importer_helper)
-- [Import Beatport Classic releases to MusicBrainz](#beatport_classic_importer)
 - [Import Beatport releases to MusicBrainz](#beatport_importer)
 - [Import Boomkat releases to Musicbrainz](#boomkat_importer)
 - [Import CD1D releases to MusicBrainz](#cd1d_importer)
@@ -49,13 +48,6 @@ Add a link to Bandcamp's album canonical URL on pages without /album/, for one t
 
 [![Source](https://github.com/jerone/UserScripts/blob/master/_resources/Source-button.png)](https://github.com/murdos/musicbrainz-userscripts/blob/master/bandcamp_importer_helper.user.js)
 [![Install](https://raw.github.com/jerone/UserScripts/master/_resources/Install-button.png)](https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer_helper.user.js)
-
-## <a name="beatport_classic_importer"></a> Import Beatport Classic releases to MusicBrainz
-
-One-click importing of releases from classic.beatport.com/release pages into MusicBrainz
-
-[![Source](https://github.com/jerone/UserScripts/blob/master/_resources/Source-button.png)](https://github.com/murdos/musicbrainz-userscripts/blob/master/beatport_classic_importer.user.js)
-[![Install](https://raw.github.com/jerone/UserScripts/master/_resources/Install-button.png)](https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_classic_importer.user.js)
 
 ## <a name="beatport_importer"></a> Import Beatport releases to MusicBrainz
 

--- a/beatport_classic_importer.user.js
+++ b/beatport_classic_importer.user.js
@@ -1,131 +1,14 @@
 // ==UserScript==
-// @name         Import Beatport Classic releases to MusicBrainz
-// @description  One-click importing of releases from classic.beatport.com/release pages into MusicBrainz
-// @version      2018.2.18.1
+// @name         [DISCONTINUED] Import Beatport Classic releases to MusicBrainz
+// @description  [DISCONTINUED] ❌ This script is discontinued because classic.beatport.com website no longer exists. ❌
+// @version      2025.10.07
 // @downloadURL  https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_classic_importer.user.js
 // @updateURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/beatport_classic_importer.user.js
-// @include      http*://classic.beatport.com/release/*
-// @require      https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js
-// @require      lib/mbimport.js
-// @require      lib/logger.js
-// @require      lib/mbimportstyle.js
+// @match        https://*/*
 // @icon         https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png
 // @grant        unsafeWindow
 // ==/UserScript==
 
-// prevent JQuery conflicts, see http://wiki.greasespot.net/@grant
-this.$ = this.jQuery = jQuery.noConflict(true);
-
-if (!unsafeWindow) unsafeWindow = window;
-
-$(document).ready(function () {
-    MBImportStyle();
-
-    let release_url = window.location.href.replace('/?.*$/', '').replace(/#.*$/, '');
-    let release = retrieveReleaseInfo(release_url);
-    insertLink(release, release_url);
-});
-
-function retrieveReleaseInfo(release_url) {
-    function contains_or(selector, list) {
-        const selectors = [];
-        $.each(list, function (ind, value) {
-            selectors.push(`${selector}:contains("${value.replace('"', '\\"')}")`);
-        });
-        return selectors.join(',');
-    }
-    let release_date_strings = [
-        'Release Date',
-        'Fecha de lanzamiento',
-        'Date de sortie',
-        'Erscheinungsdatum',
-        'Data de lançamento',
-        'Releasedatum',
-        'Data di uscita',
-        'リリース予定日',
-    ];
-    let labels_strings = ['Labels', 'Sello', 'Gravadoras', 'Label', 'Etichetta', 'Editora', 'レーベル'];
-    let catalog_strings = ['Catalog', 'Catálogo', 'Catalogue', 'Katalog', 'Catalogus', 'Catalogo', 'カタログ'];
-    let release = {};
-
-    // Release information global to all Beatport releases
-    release.packaging = 'None';
-    release.country = 'XW';
-    release.status = 'official';
-    release.urls = [];
-    release.urls.push({
-        url: release_url,
-        link_type: MBImport.URL_TYPES.purchase_for_download,
-    });
-
-    let releaseDate = $(contains_or('td.meta-data-label', release_date_strings)).next().text().split('-');
-    release.year = releaseDate[0];
-    release.month = releaseDate[1];
-    release.day = releaseDate[2];
-
-    release.labels = [];
-    release.labels.push({
-        name: $(contains_or('td.meta-data-label', labels_strings)).next().text(),
-        catno: $(contains_or('td.meta-data-label', catalog_strings)).next().text(),
-    });
-
-    let release_artists = [];
-
-    // Tracks
-    let tracks = [];
-    unsafeWindow.$('span[data-json]').each(function (index, tagSoup) {
-        let t = $.parseJSON($(tagSoup).attr('data-json'));
-        release.title = t.release.name;
-
-        let artists = [];
-        t.artists.forEach(function (artist) {
-            artists.push(artist.name);
-            release_artists.push(artist.name);
-        });
-        let title = t.name;
-        if (t.mixName && t.mixName !== 'Original Mix' && t.mixName !== 'Original') {
-            title += ` (${t.mixName})`;
-        }
-        tracks.push({
-            artist_credit: MBImport.makeArtistCredits(artists),
-            title: title,
-            duration: t.lengthMs,
-        });
-    });
-
-    let unique_artists = [];
-    $.each(release_artists, function (i, el) {
-        if ($.inArray(el, unique_artists) === -1) {
-            unique_artists.push(el);
-        }
-    });
-
-    if (unique_artists.length > 4) {
-        release.artist_credit = [MBImport.specialArtist('various_artists')];
-    } else {
-        release.artist_credit = MBImport.makeArtistCredits(unique_artists);
-    }
-    release.discs = [];
-    release.discs.push({
-        tracks: tracks,
-        format: 'Digital Media',
-    });
-
-    LOGGER.info('Parsed release: ', release);
-    return release;
-}
-
-// Insert button into page under label information
-function insertLink(release, release_url) {
-    let edit_note = MBImport.makeEditNote(release_url, 'Beatport Classic');
-    let parameters = MBImport.buildFormParameters(release, edit_note);
-
-    let mbUI = $(
-        `<div class="musicbrainz-import">${MBImport.buildFormHTML(parameters)}${MBImport.buildSearchButton(release)}</div>`,
-    ).hide();
-
-    $('.release-detail-metadata').append(mbUI);
-    $('form.musicbrainz_import').css({ display: 'inline-block', margin: '1px' });
-    $('form.musicbrainz_import img').css({ display: 'inline-block' });
-    mbUI.slideDown();
-}
+console.warn(
+    '[Import Beatport Classic releases to MusicBrainz]: ❌ This userscript has been discontinued and no longer runs. You can safely remove it from your browser. If you have any questions, go to https://github.com/murdos/musicbrainz-userscripts/issues/696',
+);


### PR DESCRIPTION
I tried to discontinue it gracefully, making sure everyone who installed the script will get a notification that it can be deleted. I think we can have it like this for a month/two, and then delete the script entirely.

I've never had to discontinue a user script before, so if there's a better approach, please let me know :)

After this update the script will display a console warning on every website, like so:
<img width="1164" height="89" alt="image" src="https://github.com/user-attachments/assets/ff0313cb-396a-4f06-936f-cf37290ee97b" />

Closes #696