### PR TITLE
build: preserve built files in `dist` folder when cleaning up all the rest for the deployment

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -38,7 +38,7 @@ jobs:
             - name: Copy built files to dist branch
               run: |
                   # Remove old built files
-                  find . -name "*.user.js" -not -path "./node_modules/*" -not -path "./.git/*" -delete
+                  find . -name "*.user.js" -not -path "./node_modules/*" -not -path "./.git/*" -not -path "./dist/*" -delete
 
                   # Copy new built files
                   cp -r dist/* .
@@ -56,7 +56,7 @@ jobs:
                     echo "No changes to commit"
                   else
                     git add .
-                    git commit -m "Build userscripts from master branch $(git rev-parse --short HEAD)"
+                    git commit --no-verify -m "Build userscripts from master branch $(git rev-parse --short HEAD)"
                     git push origin dist
                   fi
 


### PR DESCRIPTION
- don't cleanup `dist` folder when deleting old build artifacts.
- don't run `lint-staged` during the committing to the `dist` branch on CI, since it breaks the pipeline.