### PR TITLE
chore: exclude `dist/` folder from linting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
 package-lock.json
-dist/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,9 @@ import prettier from 'eslint-plugin-prettier/recommended';
 import userscripts from 'eslint-plugin-userscripts';
 
 export default defineConfig([
+    {
+        ignores: ['node_modules/**/*', 'dist/**/*'],
+    },
     js.configs.recommended,
     prettier,
     {


### PR DESCRIPTION
- for some reason it started linting it again, and .prettierignore rule didn't help today;
- I'm moving the ignore setting directly to the linter config.