### PR TITLE
chore: add eslint for TypeScript

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,12 +3,32 @@ import globals from 'globals';
 import js from '@eslint/js';
 import prettier from 'eslint-plugin-prettier/recommended';
 import userscripts from 'eslint-plugin-userscripts';
+import tseslint from 'typescript-eslint';
 
 export default defineConfig([
     {
         ignores: ['node_modules/**/*', 'dist/**/*'],
     },
     js.configs.recommended,
+    {
+        languageOptions: {
+            globals: {
+                ...globals.browser,
+                ...globals.node,
+                ...globals.greasemonkey,
+                ...globals.jquery,
+            },
+            parserOptions: {
+                projectService: true,
+            },
+        },
+        files: ['**/*.ts'],
+        extends: [tseslint.configs.strictTypeChecked],
+        rules: {
+            '@typescript-eslint/restrict-template-expressions': ['error', { allowNumber: true }],
+            '@typescript-eslint/no-non-null-assertion': 'off', // TODO: add correct guardrails and remove this in the future
+        },
+    },
     prettier,
     {
         files: ['*.user.js'],
@@ -20,6 +40,13 @@ export default defineConfig([
         rules: {
             ...userscripts.configs.recommended.rules,
             'userscripts/no-invalid-headers': ['error', { allowed: ['licence'] }],
+            'no-console': 'off',
+        },
+    },
+    {
+        files: ['**/*.js'],
+        rules: {
+            'no-unused-vars': 'warn',
         },
     },
     {
@@ -39,7 +66,6 @@ export default defineConfig([
         rules: {
             'prettier/prettier': 'error',
             'prefer-template': 'error',
-            'no-console': 'off',
             'no-inner-declarations': 'warn',
             'no-global-assign': 'warn',
             'no-redeclare': 'warn',
@@ -47,7 +73,6 @@ export default defineConfig([
             'no-undef': 'warn',
             'no-useless-concat': 'warn',
             'no-useless-escape': 'warn',
-            'no-unused-vars': 'warn',
             'no-var': 'warn',
         },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,9 @@
                 "prettier": "^3.6.2",
                 "rollup": "^4.40.2",
                 "tsx": "^4.19.4",
-                "typescript": "^5.8.3"
+                "typescript": "^5.8.3",
+                "typescript-eslint": "^8.46.1",
+                "zod": "^4.1.12"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -2326,6 +2328,44 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/@pkgr/core": {
             "version": "0.2.7",
             "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
@@ -2867,6 +2907,290 @@
             "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.1.tgz",
+            "integrity": "sha512-rUsLh8PXmBjdiPY+Emjz9NX2yHvhS11v0SR6xNJkm5GM1MO9ea/1GoDKlHHZGrOJclL/cZ2i/vRUYVtjRhrHVQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.10.0",
+                "@typescript-eslint/scope-manager": "8.46.1",
+                "@typescript-eslint/type-utils": "8.46.1",
+                "@typescript-eslint/utils": "8.46.1",
+                "@typescript-eslint/visitor-keys": "8.46.1",
+                "graphemer": "^1.4.0",
+                "ignore": "^7.0.0",
+                "natural-compare": "^1.4.0",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^8.46.1",
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/@typescript-eslint/parser": {
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.1.tgz",
+            "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "8.46.1",
+                "@typescript-eslint/types": "8.46.1",
+                "@typescript-eslint/typescript-estree": "8.46.1",
+                "@typescript-eslint/visitor-keys": "8.46.1",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/project-service": {
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.1.tgz",
+            "integrity": "sha512-FOIaFVMHzRskXr5J4Jp8lFVV0gz5ngv3RHmn+E4HYxSJ3DgDzU7fVI1/M7Ijh1zf6S7HIoaIOtln1H5y8V+9Zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.46.1",
+                "@typescript-eslint/types": "^8.46.1",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.1.tgz",
+            "integrity": "sha512-weL9Gg3/5F0pVQKiF8eOXFZp8emqWzZsOJuWRUNtHT+UNV2xSJegmpCNQHy37aEQIbToTq7RHKhWvOsmbM680A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.46.1",
+                "@typescript-eslint/visitor-keys": "8.46.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.1.tgz",
+            "integrity": "sha512-X88+J/CwFvlJB+mK09VFqx5FE4H5cXD+H/Bdza2aEWkSb8hnWIQorNcscRl4IEo1Cz9VI/+/r/jnGWkbWPx54g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils": {
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.1.tgz",
+            "integrity": "sha512-+BlmiHIiqufBxkVnOtFwjah/vrkF4MtKKvpXrKSPLCkCtAp8H01/VV43sfqA98Od7nJpDcFnkwgyfQbOG0AMvw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.46.1",
+                "@typescript-eslint/typescript-estree": "8.46.1",
+                "@typescript-eslint/utils": "8.46.1",
+                "debug": "^4.3.4",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/types": {
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.1.tgz",
+            "integrity": "sha512-C+soprGBHwWBdkDpbaRC4paGBrkIXxVlNohadL5o0kfhsXqOC6GYH2S/Obmig+I0HTDl8wMaRySwrfrXVP8/pQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.1.tgz",
+            "integrity": "sha512-uIifjT4s8cQKFQ8ZBXXyoUODtRoAd7F7+G8MKmtzj17+1UbdzFl52AzRyZRyKqPHhgzvXunnSckVu36flGy8cg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.46.1",
+                "@typescript-eslint/tsconfig-utils": "8.46.1",
+                "@typescript-eslint/types": "8.46.1",
+                "@typescript-eslint/visitor-keys": "8.46.1",
+                "debug": "^4.3.4",
+                "fast-glob": "^3.3.2",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+            "version": "7.7.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/utils": {
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.1.tgz",
+            "integrity": "sha512-vkYUy6LdZS7q1v/Gxb2Zs7zziuXN0wxqsetJdeZdRe/f5dwJFglmuvZBfTUivCtjH725C1jWCDfpadadD95EDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.7.0",
+                "@typescript-eslint/scope-manager": "8.46.1",
+                "@typescript-eslint/types": "8.46.1",
+                "@typescript-eslint/typescript-estree": "8.46.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.1.tgz",
+            "integrity": "sha512-ptkmIf2iDkNUjdeu2bQqhFPV1m6qTnFFjg7PPDjxKWaMaP0Z6I9l30Jr3g5QqbZGdw8YdYvLp+XnqnWWZOg/NA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.46.1",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
         },
         "node_modules/acorn": {
             "version": "8.15.0",
@@ -4223,6 +4547,36 @@
             "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
             "dev": true
         },
+        "node_modules/fast-glob": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fast-glob/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4234,6 +4588,16 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
+        },
+        "node_modules/fastq": {
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+            "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
         },
         "node_modules/file-entry-cache": {
             "version": "8.0.0",
@@ -4512,6 +4876,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/graphemer": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+            "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/has-bigints": {
             "version": "1.1.0",
@@ -5300,6 +5671,16 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/micromatch": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -5680,6 +6061,27 @@
                 "node": ">=6"
             }
         },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/reflect.getprototypeof": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -5839,6 +6241,17 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/reusify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/rfdc": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -5886,6 +6299,30 @@
                 "@rollup/rollup-win32-x64-gnu": "4.52.4",
                 "@rollup/rollup-win32-x64-msvc": "4.52.4",
                 "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
             }
         },
         "node_modules/safe-array-concat": {
@@ -6306,6 +6743,19 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/ts-api-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+            "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.12"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4"
+            }
+        },
         "node_modules/tsconfig-paths": {
             "version": "3.15.0",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -6440,6 +6890,30 @@
             },
             "engines": {
                 "node": ">=14.17"
+            }
+        },
+        "node_modules/typescript-eslint": {
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.1.tgz",
+            "integrity": "sha512-VHgijW803JafdSsDO8I761r3SHrgk4T00IdyQ+/UsthtgPRsBWQLqoSxOolxTpxRKi1kGXK0bSz4CoAc9ObqJA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/eslint-plugin": "8.46.1",
+                "@typescript-eslint/parser": "8.46.1",
+                "@typescript-eslint/typescript-estree": "8.46.1",
+                "@typescript-eslint/utils": "8.46.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/unbox-primitive": {
@@ -6732,6 +7206,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "4.1.12",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+            "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -52,10 +52,12 @@
         "prettier": "^3.6.2",
         "rollup": "^4.40.2",
         "tsx": "^4.19.4",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "typescript-eslint": "^8.46.1",
+        "zod": "^4.1.12"
     },
     "lint-staged": {
         "*.{json,md,yml}": "prettier --write",
-        "*.js": "eslint --fix"
+        "*.{js,ts,tsx}": "eslint --fix"
     }
 }

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -5,6 +5,7 @@ import { babel, type RollupBabelInputPluginOptions } from '@rollup/plugin-babel'
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import alias, { type Alias } from '@rollup/plugin-alias';
+import { z } from 'zod';
 
 const EXTENSIONS = ['.js', '.ts'];
 const BABEL_OPTIONS = {
@@ -25,18 +26,25 @@ const BABEL_OPTIONS = {
     ],
 } satisfies RollupBabelInputPluginOptions;
 
-interface UserscriptMetadata {
-    name: string;
-    description: string;
-    version: string;
-    author: string;
-    namespace: string;
-    match: string[];
-    require?: string[];
-    grant?: string[];
-    exclude?: string[];
-    [key: string]: any;
-}
+const MetadataSchema = z
+    .strictObject({
+        name: z.string(),
+        description: z.string(),
+        version: z.string(),
+        author: z.string(),
+        namespace: z.string(),
+        downloadURL: z.string(),
+        updateURL: z.string(),
+        match: z.array(z.string()).optional(),
+        include: z.array(z.string()).optional(),
+        require: z.array(z.string()).optional(),
+        icon: z.string().optional(),
+    })
+    .refine(data => (data.match && !data.include) || (!data.match && data.include), {
+        message: 'Either `match` or `include` must be provided, not both.',
+        path: ['match', 'include'],
+    });
+type UserscriptMetadata = z.infer<typeof MetadataSchema>;
 
 async function buildUserscript(userscriptName: string): Promise<void> {
     console.log(`Building ${userscriptName}`);
@@ -75,12 +83,12 @@ async function buildUserscript(userscriptName: string): Promise<void> {
     });
 
     // Load metadata
-    const metadataPath = path.resolve('./src/userscripts', userscriptName, 'meta.ts');
-    const metadataModule = await import(metadataPath);
-    const metadata: UserscriptMetadata = metadataModule.default;
+    const metadataPath = path.resolve('./src/userscripts', userscriptName, 'meta.json');
+    const metadata = JSON.parse(await fs.readFile(metadataPath, 'utf8')) as unknown;
+    const typedMetadata = MetadataSchema.parse(metadata);
 
     // Generate userscript header
-    const header = generateUserscriptHeader(metadata);
+    const header = generateUserscriptHeader(typedMetadata);
 
     // Combine header and code
     const finalCode = `${header}\n\n${output[0].code}`;
@@ -96,51 +104,33 @@ async function buildUserscript(userscriptName: string): Promise<void> {
 function generateUserscriptHeader(metadata: UserscriptMetadata): string {
     const lines = ['==UserScript=='];
 
-    // Required fields
     lines.push(`@name         ${metadata.name}`);
     lines.push(`@description  ${metadata.description}`);
     lines.push(`@version      ${metadata.version}`);
     lines.push(`@author       ${metadata.author}`);
     lines.push(`@namespace    ${metadata.namespace}`);
+    lines.push(`@downloadURL  ${metadata.downloadURL}`);
+    lines.push(`@updateURL    ${metadata.updateURL}`);
 
-    // Match patterns
     if (metadata.match) {
         metadata.match.forEach(pattern => {
             lines.push(`@match        ${pattern}`);
         });
-    }
-
-    // Exclude patterns
-    if (metadata.exclude) {
-        metadata.exclude.forEach(pattern => {
-            lines.push(`@exclude      ${pattern}`);
+    } else if (metadata.include) {
+        metadata.include.forEach(pattern => {
+            lines.push(`@include      ${pattern}`);
         });
     }
 
-    // Requires
     if (metadata.require) {
         metadata.require.forEach(url => {
             lines.push(`@require      ${url}`);
         });
     }
 
-    // Grants
-    if (metadata.grant) {
-        metadata.grant.forEach(grant => {
-            lines.push(`@grant        ${grant}`);
-        });
+    if (metadata.icon) {
+        lines.push(`@icon         ${metadata.icon}`);
     }
-
-    // Other metadata
-    Object.entries(metadata).forEach(([key, value]) => {
-        if (!['name', 'description', 'version', 'author', 'namespace', 'match', 'exclude', 'require', 'grant'].includes(key)) {
-            if (Array.isArray(value)) {
-                value.forEach(v => lines.push(`@${key.padEnd(12)} ${v}`));
-            } else {
-                lines.push(`@${key.padEnd(12)} ${value}`);
-            }
-        }
-    });
 
     lines.push('==/UserScript==');
 
@@ -171,4 +161,4 @@ async function main(): Promise<void> {
     }
 }
 
-main();
+await main();

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,4 +1,4 @@
-enum LogLevel {
+export enum LogLevel {
     DEBUG = 'debug',
     INFO = 'info',
     ERROR = 'error',
@@ -13,15 +13,15 @@ export class Logger {
         this.LOG_LEVEL = level;
     }
 
-    debug(...args: any[]): void {
+    debug(...args: unknown[]): void {
         this._log(LogLevel.DEBUG, args);
     }
 
-    info(...args: any[]): void {
+    info(...args: unknown[]): void {
         this._log(LogLevel.INFO, args);
     }
 
-    error(...args: any[]): void {
+    error(...args: unknown[]): void {
         this._log(LogLevel.ERROR, args);
     }
 
@@ -29,7 +29,7 @@ export class Logger {
         this.LOG_LEVEL = level;
     }
 
-    private _log(level: LogLevel, args: any[]): void {
+    private _log(level: LogLevel, args: unknown[]): void {
         if (level < this.LOG_LEVEL) {
             return;
         }

--- a/src/lib/mbimport/buildFormHTML.ts
+++ b/src/lib/mbimport/buildFormHTML.ts
@@ -5,7 +5,7 @@ export function buildFormHTML(parameters: FormParameter[]): string {
     // Build form
     let innerHTML = `<form class="musicbrainz_import musicbrainz_import_add" action="https://musicbrainz.org/release/add" method="post" target="_blank" accept-charset="UTF-8" charset="${document.characterSet}">`;
     parameters.forEach(function (parameter) {
-        const value = `${parameter.value}`;
+        const value = parameter.value.toString();
         innerHTML += `<input type='hidden' value='${value.replace(/'/g, '&apos;')}' name='${parameter.name}'/>`;
     });
 

--- a/src/lib/mbimport/buildFormParameters.ts
+++ b/src/lib/mbimport/buildFormParameters.ts
@@ -5,7 +5,6 @@ import { hmsToMilliSeconds } from '~/lib/shared/time-functions';
 import { guessReleaseType } from './guessReleaseType';
 
 function buildArtistCreditsFormParameters(parameters: FormParameter[], paramPrefix: string, artist_credit: ArtistCredit[]): void {
-    if (!artist_credit) return;
     for (let i = 0; i < artist_credit.length; i++) {
         const ac = artist_credit[i];
         if (ac) {
@@ -115,8 +114,8 @@ export function buildFormParameters(release: Release, edit_note?: string): FormP
                         total_duration += duration_ms;
                     }
                     appendParameter(parameters, `mediums.${i}.track.${j}.length`, tracklength);
-                    // @ts-ignore TODO: recording is not a property of Track and in no importer scripts a recording is found in a track. Once all scripts are migrated, we need to see if we can remove this line entirely.
-                    appendParameter(parameters, `mediums.${i}.track.${j}.recording`, track.recording);
+                    // @ts-expect-error TODO: recording is not a property of Track and in no importer scripts a recording is found in a track. Once all scripts are migrated, we need to see if we can remove this line entirely.
+                    if (track.recording) appendParameter(parameters, `mediums.${i}.track.${j}.recording`, track.recording); // eslint-disable-line @typescript-eslint/no-unsafe-argument
                     buildArtistCreditsFormParameters(parameters, `mediums.${i}.track.${j}.`, track.artist_credit);
                 }
             }

--- a/src/lib/mbimport/guessReleaseType.ts
+++ b/src/lib/mbimport/guessReleaseType.ts
@@ -7,9 +7,9 @@ export function guessReleaseType(title: string, num_tracks: number, duration_ms:
         has_single = false;
         has_EP = false;
     }
-    let perhaps_single = (has_single && num_tracks <= 4) || num_tracks <= 2;
-    let perhaps_EP = has_EP || (num_tracks > 2 && num_tracks <= 6);
-    let perhaps_album = num_tracks > 8;
+    const perhaps_single = (has_single && num_tracks <= 4) || num_tracks <= 2;
+    const perhaps_EP = has_EP || (num_tracks > 2 && num_tracks <= 6);
+    const perhaps_album = num_tracks > 8;
     if (isNaN(duration_ms)) {
         // no duration, try to guess with title and number of tracks
         if (perhaps_single && !perhaps_EP && !perhaps_album) return 'single';

--- a/src/lib/mbimport/makeArtistCredits.ts
+++ b/src/lib/mbimport/makeArtistCredits.ts
@@ -2,7 +2,7 @@ import type { ArtistCredit } from '~/types/importers';
 
 // Convert a list of artists to a list of artist credits with joinphrases
 export function makeArtistCredits(artists_list: string[]): ArtistCredit[] {
-    let artists: ArtistCredit[] = artists_list.map(function (item) {
+    const artists: ArtistCredit[] = artists_list.map(function (item) {
         return { artist_name: item };
     });
     if (artists.length > 2) {

--- a/src/lib/shared/search-params.ts
+++ b/src/lib/shared/search-params.ts
@@ -28,7 +28,7 @@ export function searchParams(release: Release): FormParameter[] {
         }
     }
 
-    let query =
+    const query =
         `artist:(${luceneEscape(release_artist)})` +
         ` release:(${luceneEscape(release.title)})` +
         ` tracks:(${totaltracks})${release.country ? ` country:${release.country}` : ''}`;

--- a/src/lib/shared/time-functions.ts
+++ b/src/lib/shared/time-functions.ts
@@ -1,6 +1,6 @@
 // convert HH:MM:SS or MM:SS to milliseconds
 export function hmsToMilliSeconds(str: number | string | undefined): number {
-    if (typeof str == 'undefined' || str === null || str === '' || isNaN(Number(str))) return NaN;
+    if (typeof str == 'undefined' || str === '' || isNaN(Number(str))) return NaN;
     if (typeof str == 'number') return str;
     const t = str.split(':');
     let s = 0;

--- a/src/types/userscript.d.ts
+++ b/src/types/userscript.d.ts
@@ -13,7 +13,7 @@ declare global {
 }
 
 // Make jQuery available globally
-declare const jQuery: typeof import('jquery');
-declare const $: typeof import('jquery');
+declare const jQuery: typeof import('jquery'); // eslint-disable-line
+declare const $: typeof import('jquery'); // eslint-disable-line
 
 export {};

--- a/src/userscripts/beatport_importer/index.ts
+++ b/src/userscripts/beatport_importer/index.ts
@@ -1,10 +1,10 @@
 import { type ArtistCredit, type Disc, type Label, type Release, type Track, type URL } from '~/types/importers';
 import { MBImport } from '~/lib/mbimport';
-import { Logger } from '~/lib/logger';
+import { Logger, LogLevel } from '~/lib/logger';
 import { MBImportStyle } from '~/lib/mbimportstyle';
 import type { BeatportPageData, BeatportReleaseData, BeatportTrackData } from './types';
 
-const LOGGER = new Logger('beatport_importer');
+const LOGGER = new Logger('beatport_importer', LogLevel.INFO);
 
 // prevent JQuery conflicts, see http://wiki.greasespot.net/@grant
 window.$ = window.jQuery = jQuery.noConflict(true);
@@ -14,7 +14,7 @@ $(document).ready(() => {
 
     const release_url = window.location.href.replace('/?.*$/', '').replace(/#.*$/, '');
 
-    const data: BeatportPageData = JSON.parse(document.getElementById('__NEXT_DATA__')!.innerHTML);
+    const data = JSON.parse(document.getElementById('__NEXT_DATA__')!.innerHTML) as unknown as BeatportPageData;
     const release_data = data.props.pageProps.release;
 
     // Reversing is less reliable, but the API does not provide track numbers.
@@ -23,7 +23,7 @@ $(document).ready(() => {
     const tracks_release = $.grep(data.props.pageProps.dehydratedState.queries, element =>
         element ? /tracks/g.test(element.queryKey) : false,
     )[0];
-    const tracks_data_array = tracks_release?.state?.data?.results;
+    const tracks_data_array = tracks_release?.state?.data.results;
     if (!tracks_data_array) {
         LOGGER.error('Could not find tracks data');
         return;
@@ -35,7 +35,9 @@ $(document).ready(() => {
 
     const mbrelease = retrieveReleaseInfo(release_url, release_data, tracks_data);
 
-    setTimeout(() => insertLink(mbrelease, release_url, isrcs), 1000);
+    setTimeout(() => {
+        insertLink(mbrelease, release_url, isrcs);
+    }, 1000);
 });
 
 function retrieveReleaseInfo(release_url: string, release_data: BeatportReleaseData, tracks_data: BeatportTrackData[]): Release {

--- a/src/userscripts/beatport_importer/meta.json
+++ b/src/userscripts/beatport_importer/meta.json
@@ -1,0 +1,12 @@
+{
+    "name": "Import Beatport releases to MusicBrainz",
+    "description": "One-click importing of releases from beatport.com/release pages into MusicBrainz",
+    "version": "2025.10.20.2",
+    "author": "VxJasonxV",
+    "namespace": "https://github.com/murdos/musicbrainz-userscripts/",
+    "downloadURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/beatport_importer.user.js",
+    "updateURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/beatport_importer.user.js",
+    "match": ["https://www.beatport.com/release/*"],
+    "require": ["https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"],
+    "icon": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png"
+}


### PR DESCRIPTION
- chose the strictest config (however some rules we have to disable for now);
- convert metadata file to JSON, since it doesn't need to be TS at this point;
- add schema validation for metadata file and make sure it conforms to the type, instead of typecasting;
- remove optional properties from build of the metadata: it's better to always know what we're dealing with and the schema can always be expanded if necessary;
- resolve all found issues in TS code.