### PR TITLE
Relationship shortcuts: Added ACUM Shortcut

### DIFF
--- a/mb_relationship_shortcuts.user.js
+++ b/mb_relationship_shortcuts.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Display shortcut for relationships on MusicBrainz
 // @description  Display icon shortcut for relationships of release-group, release, recording and work: e.g. Amazon, Discogs, Wikipedia, ... links. This allows to access some relationships without opening the entity page.
-// @version      2025.11.13
+// @version      2025.12.10
 // @author       Aurelien Mino <aurelien.mino@gmail.com>
 // @licence      GPL (http://www.gnu.org/copyleft/gpl.html)
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/mb_relationship_shortcuts.user.js
@@ -44,6 +44,7 @@ const otherDatabasesIconClasses = {
     'www.musik-sammler.de': 'musiksammler',
     'rateyourmusic.com': 'rateyourmusic',
     'www.worldcat.org': 'worldcat',
+    'nocs.acum.org.il': 'acum',
 };
 
 const streamingIconClasses = {


### PR DESCRIPTION
This has been added to the other databases whitelist and I want to add the icon into the shortcut relationship script.

<img width="1255" height="207" alt="image" src="https://github.com/user-attachments/assets/5057f1a9-4643-4617-9553-008443d42b3f" />
