### PR TITLE
fix(mblinks): batch lookup of a single entity gets ignored due to unexpected API response

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Bandcamp releases to MusicBrainz
 // @description  Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2025.09.05
+// @version      2025.12.22
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js

--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -307,6 +307,33 @@ const MBLinks = function (user_cache_key, version, expiration) {
                         }
                     });
                     mblinks.saveCache();
+                } else if ('relations' in data && 'resource' in data) {
+                    /**
+                     * For some reason, for a single entity request the API response has a different shape.
+                     */
+                    const matching_url_data = batch.find(u => u.url === data.resource);
+                    if (matching_url_data) {
+                        const key = matching_url_data.key || matching_url_data.url;
+                        const _type = matching_url_data.mb_type.replace('-', '_');
+
+                        if (!mblinks.cache[key]) {
+                            mblinks.cache[key] = {
+                                timestamp: new Date().getTime(),
+                                urls: [],
+                            };
+                        }
+
+                        data.relations.forEach(relation => {
+                            if (_type in relation) {
+                                const mb_url = `${mblinks.mb_server}/${matching_url_data.mb_type}/${relation[_type].id}`;
+                                if ($.inArray(mb_url, mblinks.cache[key].urls) === -1) {
+                                    mblinks.cache[key].urls.push(mb_url);
+                                    matching_url_data.insert_func(mblinks.createMusicBrainzLink(mb_url, _type));
+                                }
+                            }
+                        });
+                        mblinks.saveCache();
+                    }
                 }
             });
 


### PR DESCRIPTION
- currently batch lookup is used only in the Bandcamp Importer, so only that script version is bumped;

Closes #680