### PR TITLE
discogs: fix missing import/mbUI actions

### DIFF
--- a/discogs_importer.user.js
+++ b/discogs_importer.user.js
@@ -2,7 +2,7 @@
 
 // @name         Import Discogs releases to MusicBrainz
 // @description  Add a button to import Discogs releases to MusicBrainz and add links to matching MusicBrainz entities for various Discogs entities (artist,release,master,label)
-// @version      2025.08.13
+// @version      2026.01.29
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/discogs_importer.user.js
 // @updateURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/discogs_importer.user.js
@@ -405,17 +405,18 @@ function MBIDfromUrl(url, discogs_type, mb_type) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 function insertMbUI(mbUI) {
-    let e;
-    if ((e = $('#release-marketplace')) && e.length) {
-        e.before(mbUI);
-    }
-    // FIXME: the following selectors are broken since the 2021-08-09 release page update, not sure why there are three alternative selectors
-    else if ((e = $('div.section.collections')) && e.length) {
-        e.after(mbUI);
-    } else if ((e = $('#statistics')) && e.length) {
-        e.before(mbUI);
-    } else if ((e = $('div.section.social')) && e.length) {
-        e.before(mbUI);
+    for (const sel of [
+        // As of 2026-01-27, only appears in discogs UI when not logged in
+        // see: https://github.com/murdos/musicbrainz-userscripts/issues/777
+        '#release-marketplace',
+        '#shopping-box-host', // <- equivalent to #marketplace when logged in
+        '#release-stats', // <- formerly #statistics (until ~2021-08-09)
+    ]) {
+        const section = $(sel);
+        if (section.length > 0) {
+            section.before(mbUI);
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
Resolves #777

There was an update to the Discogs UI such that the reference element with selector #release-marketplace no longer appears when the user is logged in, though it does when logged out.

To make the fallbacks more maintainable, I adjusted it to cycle through them in a loop instead of using if-else blocks. Let me know if it's preferable the other way, but I thought this made it more readable/easier to maintain when adjusting and annotating fallsbacks.

As for adjustments to the fallbacks:
- Left #release-marketplace as-is. The fact that it's still there when logged out suggests this may be a temporary state of affairs.
- Added #shopping-box-host as the first fallback, as this section contains the same elements #release-marketplace did before.
- Removed the broken-since-2021 fallbacks #statistics, div.section.collections, and div.section.social
- Added #release-stats, which is present on the page and points to the stats section previously referenced by the #statistics