### PR TITLE
fix(MBLinks): avoid matching empty cache entries

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Bandcamp releases to MusicBrainz
 // @description  Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2025.12.23.1
+// @version      2026.02.06.1
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js

--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -136,6 +136,8 @@ const MBLinks = function (user_cache_key, version, expiration) {
     this.is_cached = function (key) {
         return (
             this.cache[key] &&
+            this.cache[key].urls &&
+            this.cache[key].urls.length > 0 &&
             this.expirationMinutes > 0 &&
             new Date().getTime() < this.cache[key].timestamp + this.expirationMinutes * 60 * 1000
         );


### PR DESCRIPTION
- Improved cache validation logic in mblinks.js to ensure that URLs are present and the cache is valid before accessing it.
- Previous logic led to some oddities when certain links would not be always displayed.

I noticed this on bandcamp.com, but other sites are potentially also affected as it is not clear what leads to empty URL arrays.