### PR TITLE
fix(bandcamp_importer): lookup buttons showing before MB link search on band/label stub pages

### DIFF
--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -177,8 +177,9 @@ const MBLinks = function (user_cache_key, version, expiration) {
      * @param {string} mb_type - The type of the MusicBrainz entity.
      * @param {function} insert_func - The function to call with the matching MB links.
      * @param {string} [key] - The optional key to use for the cache.
+     * @param {function} [onComplete] - Optional callback invoked when the request finishes (with or without results).
      */
-    this.searchAndDisplayMbLink = function (url, mb_type, insert_func, key) {
+    this.searchAndDisplayMbLink = function (url, mb_type, insert_func, key, onComplete) {
         let mblinks = this;
         let _type = mb_type.replace('-', '_'); // underscored type
 
@@ -187,16 +188,24 @@ const MBLinks = function (user_cache_key, version, expiration) {
             $.each(mblinks.cache[key].urls, function (idx, mb_url) {
                 insert_func(mblinks.createMusicBrainzLink(mb_url, _type));
             });
+            if (typeof onComplete === 'function') {
+                onComplete();
+            }
         } else {
             // webservice query url
             let query = `${mblinks.mb_server}/ws/2/url?resource=${encodeURIComponent(url)}&inc=${mb_type}-rels`;
 
             // Merge with previous context if there's already a pending ajax request
             let handlers = [];
+            let completionHandlers = [];
             if (query in mblinks.ajax_requests) {
                 handlers = mblinks.ajax_requests[query].context.handlers;
+                completionHandlers = mblinks.ajax_requests[query].context.completionHandlers;
             }
             handlers.push(insert_func);
+            if (typeof onComplete === 'function') {
+                completionHandlers.push(onComplete);
+            }
 
             mblinks.ajax_requests.push(
                 // key
@@ -226,6 +235,10 @@ const MBLinks = function (user_cache_key, version, expiration) {
                             });
                             mbl.saveCache();
                         }
+                    }).always(function () {
+                        $.each(ctx.completionHandlers, function (i, fn) {
+                            fn();
+                        });
                     });
                 },
 
@@ -233,6 +246,7 @@ const MBLinks = function (user_cache_key, version, expiration) {
                 {
                     key: key, // cache key
                     handlers: handlers, // list of handlers
+                    completionHandlers: completionHandlers,
                     mb_type: mb_type, // musicbrainz type ie. release-group
                     _type: _type, // musicbrainz type '-' replaced, ie. release_group
                     query: query, // json request url


### PR DESCRIPTION
Only show the "Search on MusicBrainz" (A?/L?) lookup buttons after both artist and label MB link lookups have finished. Previously they ran immediately, so isLinkInserted was still false and the buttons always appeared, even when a link was later inserted by the async callbacks.

This block runs only on blank discography (stub) pages—band or label pages with no albums—where we search for an MB artist/label link and fall back to lookup buttons if none is found.

- lib/mblinks.js: add optional onComplete callback to searchAndDisplayMbLink
- bandcamp_importer.user.js: gate lookup buttons on both searches completing

Test: https://eastpaddycicadas.bandcamp.com

Before the change:

<img width="513" height="536" alt="image" src="https://github.com/user-attachments/assets/596ce4ac-c84a-408b-9647-41f1516c7ff8" />
