### PR TITLE
fix(MBLinks): implement retry logic for JSON requests

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Bandcamp releases to MusicBrainz
 // @description  Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2026.02.07.2
+// @version      2026.02.08.1
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
@@ -11,7 +11,7 @@
 // @require      https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js
 // @require      lib/mbimport.js
 // @require      lib/logger.js
-// @require      lib/mblinks.js?version=v2025.12.22.1
+// @require      lib/mblinks.js?version=v2026.02.08.1
 // @require      lib/mbimportstyle.js
 // @icon         https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png
 // @grant        unsafeWindow

--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -86,6 +86,43 @@ const MBLinks = function (user_cache_key, version, expiration) {
         }, 1000);
     };
 
+    /**
+     * GET JSON with retry on 5xx errors (e.g. 503). Retries up to 3 times with a delay between attempts.
+     * @param {string} url - The URL to request.
+     * @param {function} successCallback - Called with response data on success.
+     * @param {function} [alwaysCallback] - Called when the request is finally done (success or after giving up retries).
+     */
+    this.getJSONWithRetry = function (url, successCallback, alwaysCallback) {
+        const maxRetries = 3;
+        const retryDelayMs = 2000;
+        let attempt = 0;
+
+        function doRequest() {
+            attempt += 1;
+            $.ajax({
+                url: url,
+                dataType: 'json',
+            })
+                .done(function (data) {
+                    successCallback(data);
+                    if (typeof alwaysCallback === 'function') {
+                        alwaysCallback();
+                    }
+                })
+                .fail(function (jqXHR) {
+                    const is5xx = jqXHR.status >= 500 && jqXHR.status < 600;
+                    if (is5xx && attempt <= maxRetries) {
+                        setTimeout(doRequest, retryDelayMs);
+                    } else {
+                        if (typeof alwaysCallback === 'function') {
+                            alwaysCallback();
+                        }
+                    }
+                });
+        }
+        doRequest();
+    };
+
     this.initCache = function () {
         if (!this.supports_local_storage) return;
         // Check if we already added links for this content
@@ -215,31 +252,35 @@ const MBLinks = function (user_cache_key, version, expiration) {
                 function () {
                     let ctx = this; // context from $.proxy()
                     let mbl = ctx.mblinks;
-                    $.getJSON(ctx.query, function (data) {
-                        if ('relations' in data) {
-                            mbl.cache[ctx.key] = {
-                                timestamp: new Date().getTime(),
-                                urls: [],
-                            };
-                            $.each(data['relations'], function (idx, relation) {
-                                if (ctx._type in relation) {
-                                    let mb_url = `${mbl.mb_server}/${ctx.mb_type}/${relation[ctx._type]['id']}`;
-                                    if ($.inArray(mb_url, mbl.cache[ctx.key].urls) == -1) {
-                                        // prevent dupes
-                                        mbl.cache[ctx.key].urls.push(mb_url);
-                                        $.each(ctx.handlers, function (i, handler) {
-                                            handler(mbl.createMusicBrainzLink(mb_url, ctx._type));
-                                        });
+                    mbl.getJSONWithRetry(
+                        ctx.query,
+                        function (data) {
+                            if ('relations' in data) {
+                                mbl.cache[ctx.key] = {
+                                    timestamp: new Date().getTime(),
+                                    urls: [],
+                                };
+                                $.each(data['relations'], function (idx, relation) {
+                                    if (ctx._type in relation) {
+                                        let mb_url = `${mbl.mb_server}/${ctx.mb_type}/${relation[ctx._type]['id']}`;
+                                        if ($.inArray(mb_url, mbl.cache[ctx.key].urls) == -1) {
+                                            // prevent dupes
+                                            mbl.cache[ctx.key].urls.push(mb_url);
+                                            $.each(ctx.handlers, function (i, handler) {
+                                                handler(mbl.createMusicBrainzLink(mb_url, ctx._type));
+                                            });
+                                        }
                                     }
-                                }
+                                });
+                                mbl.saveCache();
+                            }
+                        },
+                        function () {
+                            $.each(ctx.completionHandlers, function (i, fn) {
+                                fn();
                             });
-                            mbl.saveCache();
-                        }
-                    }).always(function () {
-                        $.each(ctx.completionHandlers, function (i, fn) {
-                            fn();
-                        });
-                    });
+                        },
+                    );
                 },
 
                 // context
@@ -357,7 +398,7 @@ const MBLinks = function (user_cache_key, version, expiration) {
                 query,
                 function () {
                     let ctx = this;
-                    $.getJSON(ctx.query, function (data) {
+                    ctx.mblinks.getJSONWithRetry(ctx.query, function (data) {
                         ctx.handlers.forEach(handler => handler(data));
                     });
                 },


### PR DESCRIPTION
- MB Search has been quite unstable as of couple of months, it often returns 5xx errors upon first request, but works fine upon a retry. This PR is adding a retry mechanism to the data fetcher for MB Links that will retry the request every 2 seconds for 3 times if error 500 is received.