### PR TITLE
fix(mblinks): fix issue when duplicate elements on the same page are not linked

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Bandcamp releases to MusicBrainz
 // @description  Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2026.02.17.1
+// @version      2026.03.05.1
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
@@ -11,7 +11,7 @@
 // @require      https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js
 // @require      lib/mbimport.js
 // @require      lib/logger.js
-// @require      lib/mblinks.js?version=v2026.02.08.1
+// @require      lib/mblinks.js?version=v2026.03.05.1
 // @require      lib/mbimportstyle.js
 // @icon         https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png
 // @grant        unsafeWindow

--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -337,11 +337,15 @@ const MBLinks = function (user_cache_key, version, expiration) {
             }
             handlers.push(function (data) {
                 if ('urls' in data) {
+                    const processedResources = {};
                     data.urls.forEach(url_data => {
-                        const matching_url_data = batch.find(u => u.url === url_data.resource);
-                        if (matching_url_data) {
-                            const key = matching_url_data.key || matching_url_data.url;
-                            const _type = matching_url_data.mb_type.replace('-', '_');
+                        if (processedResources[url_data.resource]) return;
+                        processedResources[url_data.resource] = true;
+                        const matching_urls_data = batch.filter(u => u.url === url_data.resource);
+                        if (matching_urls_data.length > 0) {
+                            const reference = matching_urls_data[0];
+                            const key = reference.key || reference.url;
+                            const _type = reference.mb_type.replace('-', '_');
 
                             if (!mblinks.cache[key]) {
                                 mblinks.cache[key] = {
@@ -351,13 +355,17 @@ const MBLinks = function (user_cache_key, version, expiration) {
                             }
 
                             if ('relations' in url_data) {
+                                const insertedMbUrls = {};
                                 url_data.relations.forEach(relation => {
                                     if (_type in relation) {
-                                        const mb_url = `${mblinks.mb_server}/${matching_url_data.mb_type}/${relation[_type].id}`;
+                                        const mb_url = `${mblinks.mb_server}/${reference.mb_type}/${relation[_type].id}`;
+                                        if (insertedMbUrls[mb_url]) return;
+                                        insertedMbUrls[mb_url] = true;
                                         if ($.inArray(mb_url, mblinks.cache[key].urls) === -1) {
                                             mblinks.cache[key].urls.push(mb_url);
-                                            matching_url_data.insert_func(mblinks.createMusicBrainzLink(mb_url, _type));
                                         }
+                                        const link = mblinks.createMusicBrainzLink(mb_url, _type);
+                                        matching_urls_data.forEach(m => m.insert_func(link));
                                     }
                                 });
                             }
@@ -368,10 +376,11 @@ const MBLinks = function (user_cache_key, version, expiration) {
                     /**
                      * For some reason, for a single entity request the API response has a different shape.
                      */
-                    const matching_url_data = batch.find(u => u.url === data.resource);
-                    if (matching_url_data) {
-                        const key = matching_url_data.key || matching_url_data.url;
-                        const _type = matching_url_data.mb_type.replace('-', '_');
+                    const matching_urls_data = batch.filter(u => u.url === data.resource);
+                    if (matching_urls_data.length > 0) {
+                        const reference = matching_urls_data[0];
+                        const key = reference.key || reference.url;
+                        const _type = reference.mb_type.replace('-', '_');
 
                         if (!mblinks.cache[key]) {
                             mblinks.cache[key] = {
@@ -380,13 +389,17 @@ const MBLinks = function (user_cache_key, version, expiration) {
                             };
                         }
 
+                        const insertedMbUrls = {};
                         data.relations.forEach(relation => {
                             if (_type in relation) {
-                                const mb_url = `${mblinks.mb_server}/${matching_url_data.mb_type}/${relation[_type].id}`;
+                                const mb_url = `${mblinks.mb_server}/${reference.mb_type}/${relation[_type].id}`;
+                                if (insertedMbUrls[mb_url]) return;
+                                insertedMbUrls[mb_url] = true;
                                 if ($.inArray(mb_url, mblinks.cache[key].urls) === -1) {
                                     mblinks.cache[key].urls.push(mb_url);
-                                    matching_url_data.insert_func(mblinks.createMusicBrainzLink(mb_url, _type));
                                 }
+                                const link = mblinks.createMusicBrainzLink(mb_url, _type);
+                                matching_urls_data.forEach(m => m.insert_func(link));
                             }
                         });
                         mblinks.saveCache();

--- a/qobuz_importer.user.js
+++ b/qobuz_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Qobuz releases to MusicBrainz
 // @description  Add a button on Qobuz's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2025.12.21.2
+// @version      2026.03.05.1
 // @namespace    https://github.com/murdos/musicbrainz-userscripts
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/qobuz_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/qobuz_importer.user.js
@@ -9,7 +9,7 @@
 // @require      https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js
 // @require      lib/mbimport.js
 // @require      lib/logger.js
-// @require      lib/mblinks.js?version=v2025.12.21.1
+// @require      lib/mblinks.js?version=v2026.03.05.1
 // @require      lib/mbimportstyle.js
 // @icon         https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png
 // @run-at       document-start


### PR DESCRIPTION
This fixes the issue where multiple elements sharing the same Bandcamp URL (e.g., Featured Albums on discography pages) would only have the first one get the MusicBrainz link.

*What changed:*
1. `processedResources` – Deduplicates work when the API returns the same resource multiple times in data.urls.
2. `batch.find()` → `batch.filter()` – Uses all matching batch entries instead of only the first, so every element that shares the URL gets processed.
3. `insertedMbUrls` – Deduplicates MB URLs when multiple relations point to the same entity, avoiding duplicate cache entries and duplicate links in the DOM.
4. *Link insertion* – `matching_urls_data.forEach(m => m.insert_func(link))` ensures each matching element gets the link, instead of only the first.