### PR TITLE
feat(bandcamp,qobuz): add support to display `ended` release links in grayscale

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Bandcamp releases to MusicBrainz
 // @description  Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2026.03.05.3
+// @version      2026.03.05.4
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
@@ -11,7 +11,7 @@
 // @require      https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js
 // @require      lib/mbimport.js
 // @require      lib/logger.js
-// @require      lib/mblinks.js?version=v2026.03.05.2
+// @require      lib/mblinks.js?version=v2026.03.05.4
 // @require      lib/mbimportstyle.js
 // @icon         https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png
 // @grant        unsafeWindow

--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -45,18 +45,26 @@ const MBLinks = function (user_cache_key, version, expiration) {
 
         if (!relations) return;
 
-        const insertedMbUrls = {};
+        // Build map of mb_url -> ended (true if any relation has ended). Only relevant for release.
+        const urlData = {};
         relations.forEach(relation => {
             if (_type in relation) {
                 const mb_url = `${mblinks.mb_server}/${reference.mb_type}/${relation[_type].id}`;
-                if (insertedMbUrls[mb_url]) return;
-                insertedMbUrls[mb_url] = true;
-                if ($.inArray(mb_url, mblinks.cache[key].urls) === -1) {
-                    mblinks.cache[key].urls.push(mb_url);
-                }
-                const link = mblinks.createMusicBrainzLink(mb_url, _type);
-                matching_urls_data.forEach(m => m.insert_func(link));
+                if (!(mb_url in urlData)) urlData[mb_url] = { ended: false };
+                if (relation.ended) urlData[mb_url].ended = true;
             }
+        });
+
+        const cacheUrls = mblinks.cache[key].urls;
+        const getUrl = entry => (typeof entry === 'string' ? entry : entry.url);
+        Object.keys(urlData).forEach(mb_url => {
+            const ended = urlData[mb_url].ended;
+            const alreadyCached = cacheUrls.some(e => getUrl(e) === mb_url);
+            if (!alreadyCached) {
+                cacheUrls.push({ url: mb_url, ended: _type === 'release' ? ended : false });
+            }
+            const link = mblinks.createMusicBrainzLink(mb_url, _type, _type === 'release' ? { ended } : {});
+            matching_urls_data.forEach(m => m.insert_func(link));
         });
     }
 
@@ -103,7 +111,7 @@ const MBLinks = function (user_cache_key, version, expiration) {
     };
     this.cache = {};
     this.expirationMinutes = typeof expiration != 'undefined' && expiration !== false ? parseInt(expiration, 10) : 90 * 24 * 60; // default to 90 days
-    let cache_version = 2;
+    let cache_version = 3;
     this.user_cache_key = user_cache_key;
     this.cache_key = `${this.user_cache_key}-v${cache_version}${typeof version != 'undefined' ? `.${version}` : ''}`;
     this.mb_server = 'https://musicbrainz.org';
@@ -227,7 +235,9 @@ const MBLinks = function (user_cache_key, version, expiration) {
     // If the url is not known by the cache, no attempt will be made to request the MusicBrainz webservice, in order to keep this method synchronous.
     this.resolveMBID = function (key) {
         if (this.is_cached(key) && this.cache[key].urls.length == 1) {
-            return this.cache[key].urls[0].slice(-36);
+            const entry = this.cache[key].urls[0];
+            const mb_url = typeof entry === 'string' ? entry : entry.url;
+            return mb_url.slice(-36);
         }
     };
 
@@ -235,9 +245,11 @@ const MBLinks = function (user_cache_key, version, expiration) {
      * Create an HTML element for a MusicBrainz link with the given type and URL.
      * @param {string} mb_url - The URL of the MusicBrainz entity.
      * @param {string} _type - The type of the MusicBrainz entity.
+     * @param {Object} [options] - Optional options.
+     * @param {boolean} [options.ended] - When true and type is release, applies grayscale to the icon.
      * @returns {string} The HTML for the MusicBrainz link.
      */
-    this.createMusicBrainzLink = function (mb_url, _type) {
+    this.createMusicBrainzLink = function (mb_url, _type, options) {
         let title = `See this ${_type} on MusicBrainz`;
         let img_url = `${this.mb_server}/static/images/entity/${_type}.svg`;
         let img_src = `<img src="${img_url}" height=16 width=16 />`;
@@ -247,6 +259,9 @@ const MBLinks = function (user_cache_key, version, expiration) {
             if (ti.title) title = ti.title;
             if (ti.img_url) img_url = ti.img_url;
             if (ti.img_src) img_src = ti.img_src;
+        }
+        if (_type === 'release' && options && options.ended) {
+            img_src = img_src.replace('/>', ' style="filter: grayscale(1)" />');
         }
         return `<a href="${mb_url}" title="${title}">${img_src}</a> `;
     };
@@ -265,7 +280,8 @@ const MBLinks = function (user_cache_key, version, expiration) {
 
         if (!key) key = url;
         if (this.is_cached(key)) {
-            $.each(mblinks.cache[key].urls, function (idx, mb_url) {
+            $.each(mblinks.cache[key].urls, function (idx, cacheEntry) {
+                const mb_url = typeof cacheEntry === 'string' ? cacheEntry : cacheEntry.url;
                 insert_func(mblinks.createMusicBrainzLink(mb_url, _type));
             });
             if (typeof onComplete === 'function') {
@@ -353,8 +369,12 @@ const MBLinks = function (user_cache_key, version, expiration) {
             const key = data.key || data.url;
             if (this.is_cached(key)) {
                 // Handle cached results immediately
-                $.each(mblinks.cache[key].urls, function (idx, mb_url) {
-                    data.insert_func(mblinks.createMusicBrainzLink(mb_url, data.mb_type.replace('-', '_')));
+                const data_type = data.mb_type.replace('-', '_');
+                $.each(mblinks.cache[key].urls, function (idx, cacheEntry) {
+                    const mb_url = typeof cacheEntry === 'string' ? cacheEntry : cacheEntry.url;
+                    const ended = typeof cacheEntry === 'string' ? false : cacheEntry.ended;
+                    const options = data_type === 'release' ? { ended } : {};
+                    data.insert_func(mblinks.createMusicBrainzLink(mb_url, data_type, options));
                 });
             } else {
                 uncached_urls.push(data);

--- a/qobuz_importer.user.js
+++ b/qobuz_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Qobuz releases to MusicBrainz
 // @description  Add a button on Qobuz's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2026.03.05.2
+// @version      2026.03.05.3
 // @namespace    https://github.com/murdos/musicbrainz-userscripts
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/qobuz_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/qobuz_importer.user.js
@@ -9,7 +9,7 @@
 // @require      https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js
 // @require      lib/mbimport.js
 // @require      lib/logger.js
-// @require      lib/mblinks.js?version=v2026.03.05.2
+// @require      lib/mblinks.js?version=v2026.03.05.3
 // @require      lib/mbimportstyle.js
 // @icon         https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png
 // @run-at       document-start


### PR DESCRIPTION
<img width="285" height="424" alt="image" src="https://github.com/user-attachments/assets/f9704145-8959-4342-afab-a590d959ecc7" />
