### PR TITLE
fix(bandcamp): remove warning on releases with video links

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -143,11 +143,9 @@ const BandcampImport = {
         let showntracks = bandcampAlbumData.trackinfo.length;
         let numtracks = -1;
         let nostream = false;
-        // album description indicates number of tracks in the download
-        let match = /^\d+ track album$/.exec(document.querySelector('meta[property="og:description"]').getAttribute('content'));
-        if (match) {
-            numtracks = parseInt(match, 10);
-        }
+        // ld+json metadata contains number of tracks in the download
+        const linkeddata = JSON.parse(document.querySelector('script[type="application/ld+json"]').innerText)
+        numtracks = linkeddata.numTracks
         if (numtracks > 0 && numtracks > showntracks) {
             // display a warning if tracks in download differs from tracks shown
             $('h2.trackTitle').append(
@@ -557,12 +555,12 @@ $(document).ready(function () {
                             <a class="mb_search_link"
                                 class="musicbrainz_import"
                                 target="_blank"
-                                title="Search this artist on MusicBrainz (open in a new tab)" 
+                                title="Search this artist on MusicBrainz (open in a new tab)"
                                 href="${artistSearchUrl}"
                             ><small>A</small>?</a>
                         </span>
                         <span class="mb_valign mb_searchit">
-                            <a 
+                            <a
                                 class="mb_search_link musicbrainz_import"
                                 target="_blank"
                                 title="Search this label on MusicBrainz (open in a new tab)"


### PR DESCRIPTION
see e.g. https://wearearmsandsleepers.bandcamp.com/album/former-kingdoms

the meta tag that's currently used to detect the complete number of tracks is not reliable.
i'm not sure about the different places to test this. i'm also not sure when the linked data was added and if it's available for all releases, but it seems like relying on it globally could remove a lot of the parsing logic from the bandcamp importer and simplify it a lot.