### PR TITLE
fix(mblinks): don't show linked release icon as ended (grayscale) if at least one URL is not ended

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Bandcamp releases to MusicBrainz
 // @description  Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2026.03.14.1
+// @version      2026.04.27.1
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js

--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -45,13 +45,13 @@ const MBLinks = function (user_cache_key, version, expiration) {
 
         if (!relations) return;
 
-        // Build map of mb_url -> ended (true if any relation has ended). Only relevant for release.
+        // Build map of mb_url -> ended (true only if every relation for that URL+entity is ended).
         const urlData = {};
         relations.forEach(relation => {
             if (_type in relation) {
                 const mb_url = `${mblinks.mb_server}/${reference.mb_type}/${relation[_type].id}`;
-                if (!(mb_url in urlData)) urlData[mb_url] = { ended: false };
-                if (relation.ended) urlData[mb_url].ended = true;
+                if (!(mb_url in urlData)) urlData[mb_url] = { ended: true };
+                if (!relation.ended) urlData[mb_url].ended = false;
             }
         });
 

--- a/qobuz_importer.user.js
+++ b/qobuz_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Qobuz releases to MusicBrainz
 // @description  Add a button on Qobuz's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2026.03.05.3
+// @version      2026.04.27.1
 // @namespace    https://github.com/murdos/musicbrainz-userscripts
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/qobuz_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/qobuz_importer.user.js


### PR DESCRIPTION
- previously the logic was reverted (if at least one URL pointing to a release is ended, render the release icon in grayscale), which turns out to be incorrect. For releases where streaming and purchasing is permanently available, and free download only temporarily available we shouldn't mark such releases as ended. Example: https://time-being.bandcamp.com/album/a-dimension-reflected on the https://jourdanlaik.bandcamp.com page.
- This only affects Bandcamp Importer and Qobuz Importer for now, as they are the only users of this functions.