### PR TITLE
feat(beatport_importer): switch from atisket import to Harmony

### DIFF
--- a/lib/mbimport.js
+++ b/lib/mbimport.js
@@ -12,6 +12,8 @@
  *     var formHtml = MBImport.buildFormHTML(parameters);
  * - Addinionally, you can inject a search link to verify that the release is not already known by MusicBrainz:
  *     var linkHtml = MBImport.buildSearchLink(parsedRelease);
+ * - Or a Harmony import link (pass barcode when available, otherwise release_url):
+ *     var harmonyHtml = MBImport.buildHarmonyButton({ barcode: parsedRelease.barcode, release_url: 'https://...' });
  *
  * Expected format of release object:
  *
@@ -119,6 +121,56 @@ const MBImport = (function () {
         html += '<button type="submit" title="Search for this release in MusicBrainz (open a new tab)">Search in MB</button>';
         html += '</form>';
         return html;
+    }
+
+    // compute HTML of Harmony import link
+    function fnBuildHarmonyButton({ barcode, release_url }) {
+        const harmonyWithBarcodeURL = barcode
+            ? `https://harmony.pulsewidth.org.uk/release?gtin=${barcode}&category=all`
+            : `https://harmony.pulsewidth.org.uk/release?url=${encodeURIComponent(release_url)}&category=musicbrainz`;
+
+        const styleBlock = `
+    <style>
+        .harmony-button {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            margin: 0 !important;
+            border-radius: 5px;
+            justify-content: center;
+            cursor: pointer;
+            font-family: Arial;
+            font-size: 12px !important;
+            padding: 3px 6px;
+            border: 1px solid rgba(180,180,180,0.8) !important;
+            background-color: rgba(240,240,240,0.8) !important;
+            color: #334 !important;
+            height: 26px;
+            user-select: none;
+            text-decoration: none !important;
+        }
+
+        .harmony-button:hover {
+            background-color: rgba(250,250,250,0.9) !important;
+        }
+
+        .harmony-button:active {
+            background-color: rgba(170,170,170,0.8) !important;
+        }
+    </style>
+`;
+
+        return `
+        ${styleBlock}
+        <a
+            class="harmony-button"
+            title="Import this release into MusicBrainz using Harmony (open a new tab)"
+            target="_blank"
+            href="${harmonyWithBarcodeURL}"
+        >
+            <img src="https://harmony.pulsewidth.org.uk/favicon.svg" alt="Harmony icon" width="16" height="16" />
+            Import with Harmony
+        </a>`;
     }
 
     function fnSearchUrlFor(type, what) {
@@ -407,6 +459,7 @@ const MBImport = (function () {
     return {
         buildSearchLink: fnBuildSearchLink,
         buildSearchButton: fnBuildSearchButton,
+        buildHarmonyButton: fnBuildHarmonyButton,
         buildFormHTML: fnBuildFormHTML,
         buildFormParameters: fnBuildFormParameters,
         makeArtistCredits: fnArtistCredits,

--- a/src/lib/mbimport/buildHarmonyButton.ts
+++ b/src/lib/mbimport/buildHarmonyButton.ts
@@ -1,0 +1,53 @@
+interface Props {
+    barcode?: string | undefined;
+    release_url: string;
+}
+
+const styleBlock = `
+    <style>
+        .harmony-button {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            margin: 0 !important;
+            border-radius: 5px;
+            justify-content: center;
+            cursor: pointer;
+            font-family: Arial;
+            font-size: 12px !important;
+            padding: 3px 6px;
+            border: 1px solid rgba(180,180,180,0.8) !important;
+            background-color: rgba(240,240,240,0.8) !important;
+            color: #334 !important;
+            height: 26px;
+            user-select: none;
+            text-decoration: none !important;
+        }
+
+        .harmony-button:hover {
+            background-color: rgba(250,250,250,0.9) !important;
+        }
+
+        .harmony-button:active {
+            background-color: rgba(170,170,170,0.8) !important;
+        }
+    </style>
+`;
+
+export function buildHarmonyButton({ barcode, release_url }: Props): string {
+    const harmonyWithBarcodeURL = barcode
+        ? `https://harmony.pulsewidth.org.uk/release?gtin=${barcode}&category=all`
+        : `https://harmony.pulsewidth.org.uk/release?url=${encodeURIComponent(release_url)}&category=musicbrainz`;
+
+    return `
+        ${styleBlock}
+        <a
+            class="harmony-button"
+            title="Import this release into MusicBrainz using Harmony (open a new tab)" 
+            target="_blank" 
+            href="${harmonyWithBarcodeURL}"
+        >
+            <img src="https://harmony.pulsewidth.org.uk/favicon.svg" alt="Harmony icon" width="16" height="16" />
+            Import with Harmony
+        </a>`;
+}

--- a/src/lib/mbimport/index.ts
+++ b/src/lib/mbimport/index.ts
@@ -1,3 +1,4 @@
+import { buildHarmonyButton } from './buildHarmonyButton';
 import { buildSearchLink } from './buildSearchLink';
 import { buildSearchButton } from './buildSearchButton';
 import { buildFormHTML } from './buildFormHTML';
@@ -11,6 +12,7 @@ import { URL_TYPES } from './urlTypes';
 import { special_artists, specialArtist } from './specialArtist';
 
 export const MBImport = {
+    buildHarmonyButton,
     buildSearchLink,
     buildSearchButton,
     buildFormHTML,

--- a/src/userscripts/beatport_importer/index.ts
+++ b/src/userscripts/beatport_importer/index.ts
@@ -187,15 +187,19 @@ function insertMBButtons(mbrelease: Release, release_url: string, isrcs: (string
         return;
     }
 
-    const spanHTML = mbrelease.barcode
-        ? `<a href="https://atisket.pulsewidth.org.uk/?upc=${encodeURIComponent(mbrelease.barcode)}">
-            ${mbrelease.barcode}
-        </a>`
-        : '[none]';
+    const barcodeText = mbrelease.barcode || '[none]';
+
+    const importLinkHTML = MBImport.buildHarmonyButton({ barcode: mbrelease.barcode, release_url });
+
     const releaseInfoBarcode = document.createElement('div');
     releaseInfoBarcode.className = lastReleaseInfo.className;
     releaseInfoBarcode.id = MB_IMPORT_BARCODE_ELEMENT;
-    releaseInfoBarcode.innerHTML = `<p>Barcode</p><span>${spanHTML}</span>`;
+    releaseInfoBarcode.style = 'display: flex; align-items: center; gap: 5px; flex-wrap: wrap;';
+    releaseInfoBarcode.innerHTML = `
+        <p>Barcode</p>
+        <span>${barcodeText}</span>
+        ${importLinkHTML}
+    `;
     lastReleaseInfo.insertAdjacentElement('afterend', releaseInfoBarcode);
 }
 

--- a/src/userscripts/beatport_importer/meta.json
+++ b/src/userscripts/beatport_importer/meta.json
@@ -1,7 +1,7 @@
 {
     "name": "Import Beatport releases to MusicBrainz",
     "description": "One-click importing of releases from beatport.com/release pages into MusicBrainz",
-    "version": "2026.05.29.1",
+    "version": "2026.05.29.2",
     "author": "VxJasonxV",
     "namespace": "https://github.com/murdos/musicbrainz-userscripts/",
     "downloadURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/beatport_importer.user.js",


### PR DESCRIPTION
- if a barcode is not found for some reason (its type is nullable), we will still try to match the release using the URL since Harmony seems to support that.
- also port the code to the old JS lib, as I'm planning to reuse the button in the bandcamp script as well.
- a clickable barcode approach was extremely hard to discover in the current version, so I'm opting for a button instead.
- for now to avoid crowding, I put the button right next to the barcode, but in the future I'm thinking to move the entire buttons array to its own new row.

<img width="1393" height="519" alt="image" src="https://github.com/user-attachments/assets/de07f03e-da48-4def-8559-5acbb8135de6" />

Closes #873