### PR TITLE
feat(mb_relationship_shortcuts): add support for 7digital and Audiomack relationships icons

### DIFF
--- a/mb_relationship_shortcuts.user.js
+++ b/mb_relationship_shortcuts.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Display shortcut for relationships on MusicBrainz
 // @description  Display icon shortcut for relationships of release-group, release, recording and work: e.g. Amazon, Discogs, Wikipedia, ... links. This allows to access some relationships without opening the entity page.
-// @version      2026.5.2.2
+// @version      2026.5.28.1
 // @author       Aurelien Mino <aurelien.mino@gmail.com>
 // @licence      GPL (http://www.gnu.org/copyleft/gpl.html)
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/mb_relationship_shortcuts.user.js
@@ -50,6 +50,8 @@ const otherDatabasesIconClasses = {
 };
 
 const streamingIconClasses = {
+    '7digital.com': 'sevendigital',
+    'audiomack.com': 'audiomack',
     'music.amazon.': 'amazonmusic',
     'music.apple.com': 'applemusic',
     'bandcamp.com': 'bandcamp',


### PR DESCRIPTION
Closes #879 
Closes #878

After the change:

<img width="408" height="274" alt="image" src="https://github.com/user-attachments/assets/62c5557c-0508-4ce1-bd73-43d88a113aa6" />
