### PR TITLE
feat(set-recording-comments): Show contextual info in edit note

### DIFF
--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -201,7 +201,7 @@ function setRecordingComments() {
             $submitButton.prop('disabled', false).text('Submit changes (marked red)');
         } else {
             let editNote = $('#recording-comments-edit-note').val().trim();
-            editNote += `\n\n—\nSet recording comments for a release\nEntered from: ${location.href}`;
+            editNote += `\n\n—\nSet recording comments for a release\nEntered from: ${location.href} '''''${document.querySelector('h1')?.textContent}'''''`;
             let makeVotable = document.getElementById('make-recording-comments-votable').checked;
 
             activeRequest = $.ajax({

--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MusicBrainz: Set recording comments for a release
 // @description  Batch set recording comments from a Release page.
-// @version      2026.5.29
+// @version      2026.5.31
 // @author       Michael Wiencek
 // @license      X11
 // @namespace    790382e7-8714-47a7-bfbd-528d0caa2333
@@ -39,12 +39,9 @@
 // authorization.
 // ==/License==
 
-setTimeout(function () {
-    const scr = document.createElement('script');
-    scr.textContent = `$(${setRecordingComments});`;
-    document.body.appendChild(scr);
-}, 1000);
+setTimeout(setRecordingComments, 1000);
 
+// Keep this intermediate function in case we need to recall it on mb-hydration events, one day
 function setRecordingComments() {
     let $tracks;
     let $inputs = $();
@@ -202,7 +199,7 @@ function setRecordingComments() {
         } else {
             let editNote = $('#recording-comments-edit-note').val().trim();
             editNote += `${editNote ? '\n\n—\n' : ''}Entered from '''''${document.querySelector('h1')?.textContent}''''' at ${location.href}`;
-            editNote += `\nUsing '''Set recording comments for a release''' from https://github.com/murdos/musicbrainz-userscripts`;
+            editNote += `\nUsing '''${GM_info.script.name.replace(/^.+:/, '')}''' ${GM_info.script.version} from https://github.com/murdos/musicbrainz-userscripts`;
             let makeVotable = document.getElementById('make-recording-comments-votable').checked;
 
             activeRequest = $.ajax({

--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -198,7 +198,7 @@ function setRecordingComments() {
             $submitButton.prop('disabled', false).text('Submit changes (marked red)');
         } else {
             let editNote = $('#recording-comments-edit-note').val().trim();
-            editNote += `${editNote ? '\n\n—\n' : ''}Entered from '''''${document.querySelector('h1')?.textContent}''''' at ${location.href}`;
+            editNote += `${editNote ? '\n\n—\n' : ''}Entered from '''''${document.querySelector('.releaseheader h1')?.textContent}''''' at ${location.href}`;
             editNote += `\nUsing '''${GM_info.script.name.replace(/^.+:/, '')}''' ${GM_info.script.version} from https://github.com/murdos/musicbrainz-userscripts`;
             let makeVotable = document.getElementById('make-recording-comments-votable').checked;
 

--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MusicBrainz: Set recording comments for a release
 // @description  Batch set recording comments from a Release page.
-// @version      2024.6.18.1
+// @version      2026.5.28
 // @author       Michael Wiencek
 // @license      X11
 // @namespace    790382e7-8714-47a7-bfbd-528d0caa2333
@@ -200,7 +200,8 @@ function setRecordingComments() {
             $inputs.prop('disabled', false);
             $submitButton.prop('disabled', false).text('Submit changes (marked red)');
         } else {
-            let editNote = $('#recording-comments-edit-note').val();
+            let editNote = $('#recording-comments-edit-note').val().trim();
+            editNote += `\n\n—\nSet recording comments for a release\nEntered from: ${location.href}`;
             let makeVotable = document.getElementById('make-recording-comments-votable').checked;
 
             activeRequest = $.ajax({

--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -7,7 +7,7 @@
 // @namespace    790382e7-8714-47a7-bfbd-528d0caa2333
 // @downloadURL  https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/set-recording-comments.user.js
 // @updateURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/set-recording-comments.user.js
-// @include      /^https?:\/\/(\w+\.)?musicbrainz\.org\/release\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}(\/disc\/\d+|(\?.+?)?$)/
+// @include      /^https?:\/\/(\w+\.)?musicbrainz\.(org|eu)\/release\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}(\/disc\/\d+|(\?.+?)?$)/
 // @grant        none
 // @run-at       document-idle
 // ==/UserScript==

--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MusicBrainz: Set recording comments for a release
 // @description  Batch set recording comments from a Release page.
-// @version      2026.5.28
+// @version      2026.5.29
 // @author       Michael Wiencek
 // @license      X11
 // @namespace    790382e7-8714-47a7-bfbd-528d0caa2333
@@ -201,7 +201,8 @@ function setRecordingComments() {
             $submitButton.prop('disabled', false).text('Submit changes (marked red)');
         } else {
             let editNote = $('#recording-comments-edit-note').val().trim();
-            editNote += `\n\n—\nSet recording comments for a release\nEntered from: ${location.href} '''''${document.querySelector('h1')?.textContent}'''''`;
+            editNote += `${editNote ? '\n\n—\n' : ''}Entered from '''''${document.querySelector('h1')?.textContent}''''' at ${location.href}`;
+            editNote += `\nUsing '''Set recording comments for a release''' from https://github.com/murdos/musicbrainz-userscripts`;
             let makeVotable = document.getElementById('make-recording-comments-votable').checked;
 
             activeRequest = $.ajax({


### PR DESCRIPTION
- **Show userscript name** (hardcoded, as GM_info is not available with this userscript injection style)
- **Show release URL** (using same style as the MBS relationship editor contextual edit notes)
- I've also allowed the userscript to run on `musicbrainz.eu` server

Example test edit note
----------------------

https://test.musicbrainz.org/edit/100304628

Before my change:

```




testing empty heading and trailing lines




```

After my change:

```
testing empty heading and trailing lines

—
Set recording comments for a release
Entered from: https://test.musicbrainz.org/release/4867a85b-4288-396d-84d8-fc3739271ec7
```