### PR TITLE
feat(beatport_importer): improve Harmony lookups

### DIFF
--- a/lib/mbimport.js
+++ b/lib/mbimport.js
@@ -125,9 +125,17 @@ const MBImport = (function () {
 
     // compute HTML of Harmony import link
     function fnBuildHarmonyButton({ barcode, release_url }) {
-        const harmonyWithBarcodeURL = barcode
-            ? `https://harmony.pulsewidth.org.uk/release?gtin=${barcode}&category=all`
-            : `https://harmony.pulsewidth.org.uk/release?url=${encodeURIComponent(release_url)}&category=musicbrainz`;
+        const searchParams = new URLSearchParams();
+        if (barcode) {
+            searchParams.set('gtin', barcode);
+        }
+        if (release_url) {
+            searchParams.set('url', encodeURI(release_url));
+        }
+        searchParams.set('category', 'preferred'); // take Harmony user preferences into account
+        searchParams.set('musicbrainz', ''); // enforce lookup by barcode in MusicBrainz
+
+        const harmonyURL = `https://harmony.pulsewidth.org.uk/release?${searchParams.toString()}`;
 
         const styleBlock = `
     <style>
@@ -166,7 +174,7 @@ const MBImport = (function () {
             class="harmony-button"
             title="Import this release into MusicBrainz using Harmony (open a new tab)"
             target="_blank"
-            href="${harmonyWithBarcodeURL}"
+            href="${harmonyURL}"
         >
             <img src="https://harmony.pulsewidth.org.uk/favicon.svg" alt="Harmony icon" width="16" height="16" />
             Import with Harmony

--- a/src/lib/mbimport/buildHarmonyButton.ts
+++ b/src/lib/mbimport/buildHarmonyButton.ts
@@ -35,17 +35,26 @@ const styleBlock = `
 `;
 
 export function buildHarmonyButton({ barcode, release_url }: Props): string {
-    const harmonyWithBarcodeURL = barcode
-        ? `https://harmony.pulsewidth.org.uk/release?gtin=${barcode}&category=all`
-        : `https://harmony.pulsewidth.org.uk/release?url=${encodeURIComponent(release_url)}&category=musicbrainz`;
+    const searchParams = new URLSearchParams();
+    if (barcode) {
+        searchParams.set('gtin', barcode);
+    }
+    if (release_url) {
+        searchParams.set('url', encodeURI(release_url));
+    }
+
+    searchParams.set('category', 'preferred'); // take Harmony user preferences into account
+    searchParams.set('musicbrainz', ''); // enforce lookup by barcode in MusicBrainz
+
+    const harmonyURL = `https://harmony.pulsewidth.org.uk/release?${searchParams.toString()}`;
 
     return `
         ${styleBlock}
         <a
             class="harmony-button"
             title="Import this release into MusicBrainz using Harmony (open a new tab)" 
-            target="_blank" 
-            href="${harmonyWithBarcodeURL}"
+            target="_blank"
+            href="${harmonyURL}"
         >
             <img src="https://harmony.pulsewidth.org.uk/favicon.svg" alt="Harmony icon" width="16" height="16" />
             Import with Harmony

--- a/src/userscripts/beatport_importer/meta.json
+++ b/src/userscripts/beatport_importer/meta.json
@@ -1,7 +1,7 @@
 {
     "name": "Import Beatport releases to MusicBrainz",
     "description": "One-click importing of releases from beatport.com/release pages into MusicBrainz",
-    "version": "2026.05.29.2",
+    "version": "2026.05.30.1",
     "author": "VxJasonxV",
     "namespace": "https://github.com/murdos/musicbrainz-userscripts/",
     "downloadURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/beatport_importer.user.js",


### PR DESCRIPTION
- correctly enforce musicbrainz lookup;
- use `category: preferred` to take Harmony user preferences into account;
- supply both barcode and URL to Harmony for richer lookups

From https://github.com/murdos/musicbrainz-userscripts/pull/884#discussion_r3325554078.