### PR TITLE
feat: add icon variant for Harmony button

### DIFF
--- a/lib/mbimport.js
+++ b/lib/mbimport.js
@@ -13,7 +13,7 @@
  * - Addinionally, you can inject a search link to verify that the release is not already known by MusicBrainz:
  *     var linkHtml = MBImport.buildSearchLink(parsedRelease);
  * - Or a Harmony import link (pass barcode when available, otherwise release_url):
- *     var harmonyHtml = MBImport.buildHarmonyButton({ barcode: parsedRelease.barcode, release_url: 'https://...' });
+ *     var harmonyHtml = MBImport.buildHarmonyButton({ barcode: parsedRelease.barcode, release_url: 'https://...', variant: 'full' });
  *
  * Expected format of release object:
  *
@@ -123,21 +123,24 @@ const MBImport = (function () {
         return html;
     }
 
-    // compute HTML of Harmony import link
-    function fnBuildHarmonyButton({ barcode, release_url }) {
-        const searchParams = new URLSearchParams();
-        if (barcode) {
-            searchParams.set('gtin', barcode);
+    const styleBlockIconButton = `
+    <style>
+        .harmony-button {
+            display: inline-block;
+            position: relative;
         }
-        if (release_url) {
-            searchParams.set('url', encodeURI(release_url));
+
+        .harmony-button:hover {
+            transform: scale(1.1);
         }
-        searchParams.set('category', 'preferred'); // take Harmony user preferences into account
-        searchParams.set('musicbrainz', ''); // enforce lookup by barcode in MusicBrainz
 
-        const harmonyURL = `https://harmony.pulsewidth.org.uk/release?${searchParams.toString()}`;
+        .harmony-button:active {
+            transform: scale(0.9);
+        }
+    </style>
+`;
 
-        const styleBlock = `
+    const styleBlockFullButton = `
     <style>
         .harmony-button {
             display: flex;
@@ -168,8 +171,22 @@ const MBImport = (function () {
     </style>
 `;
 
+    // compute HTML of Harmony import link
+    function fnBuildHarmonyButton({ barcode, release_url, variant }) {
+        const searchParams = new URLSearchParams();
+        if (barcode) {
+            searchParams.set('gtin', barcode);
+        }
+        if (release_url) {
+            searchParams.set('url', encodeURI(release_url));
+        }
+        searchParams.set('category', 'preferred'); // take Harmony user preferences into account
+        searchParams.set('musicbrainz', ''); // enforce lookup by barcode in MusicBrainz
+
+        const harmonyURL = `https://harmony.pulsewidth.org.uk/release?${searchParams.toString()}`;
+
         return `
-        ${styleBlock}
+        ${variant === 'full' ? styleBlockFullButton : styleBlockIconButton}
         <a
             class="harmony-button"
             title="Import this release into MusicBrainz using Harmony (open a new tab)"
@@ -177,7 +194,7 @@ const MBImport = (function () {
             href="${harmonyURL}"
         >
             <img src="https://harmony.pulsewidth.org.uk/favicon.svg" alt="Harmony icon" width="16" height="16" />
-            Import with Harmony
+            ${variant === 'full' ? 'Import with Harmony' : ''}
         </a>`;
     }
 

--- a/src/lib/mbimport/buildHarmonyButton.ts
+++ b/src/lib/mbimport/buildHarmonyButton.ts
@@ -1,9 +1,27 @@
 interface Props {
     barcode?: string | undefined;
     release_url: string;
+    variant: 'full' | 'icon';
 }
 
-const styleBlock = `
+const styleBlockIconButton = `
+    <style>
+        .harmony-button {
+            display: inline-block;
+            position: relative;
+        }
+
+        .harmony-button:hover {
+            transform: scale(1.1);
+        }
+
+        .harmony-button:active {
+            transform: scale(0.9);
+        }
+    </style>
+`;
+
+const styleBlockFullButton = `
     <style>
         .harmony-button {
             display: flex;
@@ -34,7 +52,7 @@ const styleBlock = `
     </style>
 `;
 
-export function buildHarmonyButton({ barcode, release_url }: Props): string {
+export function buildHarmonyButton({ barcode, release_url, variant }: Props): string {
     const searchParams = new URLSearchParams();
     if (barcode) {
         searchParams.set('gtin', barcode);
@@ -49,7 +67,7 @@ export function buildHarmonyButton({ barcode, release_url }: Props): string {
     const harmonyURL = `https://harmony.pulsewidth.org.uk/release?${searchParams.toString()}`;
 
     return `
-        ${styleBlock}
+        ${variant === 'full' ? styleBlockFullButton : styleBlockIconButton}
         <a
             class="harmony-button"
             title="Import this release into MusicBrainz using Harmony (open a new tab)" 
@@ -57,6 +75,6 @@ export function buildHarmonyButton({ barcode, release_url }: Props): string {
             href="${harmonyURL}"
         >
             <img src="https://harmony.pulsewidth.org.uk/favicon.svg" alt="Harmony icon" width="16" height="16" />
-            Import with Harmony
+            ${variant === 'full' ? 'Import with Harmony' : ''}
         </a>`;
 }

--- a/src/userscripts/beatport_importer/index.ts
+++ b/src/userscripts/beatport_importer/index.ts
@@ -189,7 +189,7 @@ function insertMBButtons(mbrelease: Release, release_url: string, isrcs: (string
 
     const barcodeText = mbrelease.barcode || '[none]';
 
-    const importLinkHTML = MBImport.buildHarmonyButton({ barcode: mbrelease.barcode, release_url });
+    const importLinkHTML = MBImport.buildHarmonyButton({ barcode: mbrelease.barcode, release_url, variant: 'full' });
 
     const releaseInfoBarcode = document.createElement('div');
     releaseInfoBarcode.className = lastReleaseInfo.className;

--- a/src/userscripts/beatport_importer/meta.json
+++ b/src/userscripts/beatport_importer/meta.json
@@ -1,7 +1,7 @@
 {
     "name": "Import Beatport releases to MusicBrainz",
     "description": "One-click importing of releases from beatport.com/release pages into MusicBrainz",
-    "version": "2026.05.30.1",
+    "version": "2026.05.30.2",
     "author": "VxJasonxV",
     "namespace": "https://github.com/murdos/musicbrainz-userscripts/",
     "downloadURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/beatport_importer.user.js",


### PR DESCRIPTION
<img width="353" height="296" alt="image" src="https://github.com/user-attachments/assets/1f8d1650-2c95-47bb-8ef7-a869ec1e3b7e" />

This is just for illustration, the button on Beatport will remain full-size. This icon variant is for Bandcamp, where we have less space available.