### PR TITLE
feat(bandcamp_importer): add Harmony button; fix mobile layout

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Bandcamp releases to MusicBrainz
 // @description  Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2026.05.29.1
+// @version      2026.05.30.1
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
@@ -9,9 +9,9 @@
 // @include      /^https:\/\/([^.]+)\.bandcamp\.com((?:\/(?:(?:album|track))\/[^/]+|\/|\/music)?)$/
 // @include      /^https?:\/\/web\.archive\.org\/web\/\d+\/https?:\/\/[^/]+(?:\/(?:album|track)\/[^/]+\/?|\/music\/?|\/?)$/
 // @require      https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js
-// @require      lib/mbimport.js
+// @require      lib/mbimport.js?version=v2026.05.30.1
 // @require      lib/logger.js
-// @require      lib/mblinks.js?version=v2026.03.05.4
+// @require      lib/mblinks.js?version=v2026.05.30.1
 // @require      lib/mbimportstyle.js
 // @icon         https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png
 // @grant        unsafeWindow
@@ -231,17 +231,32 @@ const BandcampImport = {
             return false;
         }
         // Form parameters
-        let edit_note = MBImport.makeEditNote(release.url, 'Bandcamp');
-        let parameters = MBImport.buildFormParameters(release, edit_note);
+        const edit_note = MBImport.makeEditNote(release.url, 'Bandcamp');
+        const parameters = MBImport.buildFormParameters(release, edit_note);
+
+        const importButton = MBImport.buildFormHTML(parameters);
+        const searchButton = MBImport.buildSearchButton(release);
+        const harmonyButton = MBImport.buildHarmonyButton({
+            barcode: unsafeWindow.TralbumData?.current?.upc || undefined,
+            release_url: release.url,
+            variant: 'full',
+        });
+
         // Build form
-        let mbUI = $(`<div id="mb_buttons">${MBImport.buildFormHTML(parameters)}${MBImport.buildSearchButton(release)}</div>`);
+        const mbUI = document.createElement('div');
+        mbUI.id = 'mb_buttons';
+        mbUI.innerHTML = `${importButton}${searchButton}${harmonyButton}`;
 
         // Append MB import link
         if (isMobile) {
-            $('#band-navbar > ul').append($('<li>').css({ display: 'flex', alignItems: 'center', alignSelf: 'center' }).append(mbUI));
+            const bandNavbar = document.querySelector('#band-navbar');
+            if (bandNavbar) {
+                mbUI.style = 'margin: 8px; flex-wrap: wrap;';
+                bandNavbar.insertAdjacentElement('afterend', mbUI);
+            }
         } else {
             $('#name-section').append(mbUI);
-            document.querySelector('#mb_buttons').style.marginTop = '6px';
+            mbUI.style.marginTop = '6px';
         }
 
         document.querySelectorAll('form.musicbrainz_import').forEach(form => (form.style.display = 'inline-block'));
@@ -521,12 +536,12 @@ function init() {
         }
         const upc = unsafeWindow.TralbumData.current.upc;
         if (typeof upc != 'undefined' && upc !== null) {
-            document.querySelector('div #trackInfoInner').insertAdjacentHTML(
-                'beforeend',
-                `<div id="mbimport_upc" style="margin-bottom: 2em; font-size: smaller;">UPC: ${upc}<br/>
-            Import: <a href="https://harmony.pulsewidth.org.uk/release?url=${encodeURIComponent(release.url)}&category=default">Harmony</a>
-            | <a href="https://atisket.pulsewidth.org.uk/?upc=${upc}">a-tisket</a></div>`,
-            );
+            document
+                .querySelector('div #trackInfoInner')
+                .insertAdjacentHTML(
+                    'beforeend',
+                    `<div id="mbimport_upc" style="margin-bottom: 2em; font-size: smaller;">UPC: ${upc}</div>`,
+                );
         }
     }
 

--- a/lib/mbimport.js
+++ b/lib/mbimport.js
@@ -159,6 +159,7 @@ const MBImport = (function () {
             height: 26px;
             user-select: none;
             text-decoration: none !important;
+            box-sizing: border-box;
         }
 
         .harmony-button:hover {

--- a/src/lib/mbimport/buildHarmonyButton.ts
+++ b/src/lib/mbimport/buildHarmonyButton.ts
@@ -40,6 +40,7 @@ const styleBlockFullButton = `
             height: 26px;
             user-select: none;
             text-decoration: none !important;
+            box-sizing: border-box;
         }
 
         .harmony-button:hover {

--- a/src/userscripts/beatport_importer/meta.json
+++ b/src/userscripts/beatport_importer/meta.json
@@ -1,7 +1,7 @@
 {
     "name": "Import Beatport releases to MusicBrainz",
     "description": "One-click importing of releases from beatport.com/release pages into MusicBrainz",
-    "version": "2026.05.30.3",
+    "version": "2026.05.30.4",
     "author": "VxJasonxV",
     "namespace": "https://github.com/murdos/musicbrainz-userscripts/",
     "downloadURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/beatport_importer.user.js",


### PR DESCRIPTION
- removed `Import with atisket` link, since it's on its way out now;
- added Harmony button, which will lookup the release based on the barcode (if present) and bandcamp URL;
- removed now redundant 'Harmony' text link at the bottom of the page;
- boosted lib/mblinks.js cache just in case;
- fixed the layout on mobile screen.

Desktop:
<img width="614" height="636" alt="image" src="https://github.com/user-attachments/assets/b4dcaa01-f23e-495c-b305-513783faa088" />

Mobile:

<img width="375" height="399" alt="image" src="https://github.com/user-attachments/assets/3fa28c98-fd6e-4f6c-8a3c-574987e18ae9" />
