### PR TITLE
feat(bandcamp_importer): add support for importing private streams

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,12 +1,14 @@
 // ==UserScript==
 // @name         Import Bandcamp releases to MusicBrainz
 // @description  Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2026.05.31.3
+// @version      2026.05.31.4
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @include      /^https:\/\/[^/]+\/(?:(?:(?:album|track))\/[^/]+|music)$/
 // @include      /^https:\/\/([^.]+)\.bandcamp\.com((?:\/(?:(?:album|track))\/[^/]+|\/|\/music)?)$/
+// @include      /^https:\/\/bandcamp\.com\/private\//
+// @include      /^https:\/\/([^.]+)\.bandcamp\.com\/private\//
 // @include      /^https?:\/\/web\.archive\.org\/web\/\d+\/https?:\/\/[^/]+(?:\/(?:album|track)\/[^/]+\/?|\/music\/?|\/?)$/
 // @require      lib/mbimport.js?version=v2026.05.30.1
 // @require      lib/logger.js
@@ -30,14 +32,42 @@ String.prototype.fix_bandcamp_url = function () {
     return url.replace('http://', 'https://');
 };
 
+const isPrivateStreamPage = () => !!unsafeWindow.TralbumData?.is_private_stream || /^\/private\//.test(window.location.pathname);
+
+const getBandRootUrl = () => {
+    const ogUrl = document.querySelector('meta[property="og:url"]')?.getAttribute('content');
+    if (ogUrl) {
+        const match = ogUrl.match(/^(https?:\/\/[^/]+\.bandcamp\.com)/);
+        if (match) return match[1];
+    }
+    const host = window.location.hostname;
+    if (host.endsWith('.bandcamp.com') && host !== 'bandcamp.com') {
+        return `${window.location.protocol}//${host}`;
+    }
+    const bandLink = document.querySelector('a[href*=".bandcamp.com"]:not([href*="bandcamp.com/discover"])');
+    if (bandLink) {
+        const match = bandLink.href.match(/^(https?:\/\/[^/]+\.bandcamp\.com)/);
+        if (match) return match[1];
+    }
+    return null;
+};
+
+const absoluteBandcampUrl = url => {
+    url = url.fix_bandcamp_url();
+    if (url.startsWith('http')) return url.split('?')[0];
+    const root = getBandRootUrl();
+    if (root && url.startsWith('/')) return root + url.split('?')[0];
+    return url;
+};
+
 const BandcampImport = {
     // Analyze Bandcamp data and return a release object
-    retrieveReleaseInfo: function () {
+    retrieveReleaseInfo: function (isPrivateStream) {
         let bandcampAlbumData = unsafeWindow.TralbumData;
         let bandcampEmbedData = unsafeWindow.EmbedData;
         const bandcampMobileData = unsafeWindow.TralbumJSONLD;
 
-        const artist = bandcampAlbumData.artist || bandcampMobileData.byArtist.name;
+        const artist = bandcampAlbumData.artist || bandcampMobileData?.byArtist?.name;
 
         let release = {
             discs: [],
@@ -52,12 +82,12 @@ const BandcampImport = {
             format: 'Digital Media',
             country: 'XW',
             type: '',
-            status: 'official',
+            status: isPrivateStream ? 'promotion' : 'official',
             packaging: 'None',
             language: 'eng',
             script: 'Latn',
             urls: [],
-            url: bandcampAlbumData.url.fix_bandcamp_url(),
+            url: absoluteBandcampUrl(bandcampAlbumData.url),
         };
 
         // Grab release title
@@ -166,41 +196,43 @@ const BandcampImport = {
             nostream = true;
         }
 
-        // URLs
-        let link_type = MBImport.URL_TYPES;
-        // Download for free vs. for purchase
-        if (bandcampAlbumData.current.download_pref !== null) {
-            if (
-                bandcampAlbumData.freeDownloadPage !== null ||
-                bandcampAlbumData.current.download_pref === 1 ||
-                (bandcampAlbumData.current.download_pref === 2 && bandcampAlbumData.current.minimum_price === 0)
-            ) {
+        // URLs (private streams are intentionally omitted to avoid advertising them)
+        if (!isPrivateStream) {
+            let link_type = MBImport.URL_TYPES;
+            // Download for free vs. for purchase
+            if (bandcampAlbumData.current.download_pref !== null) {
+                if (
+                    bandcampAlbumData.freeDownloadPage !== null ||
+                    bandcampAlbumData.current.download_pref === 1 ||
+                    (bandcampAlbumData.current.download_pref === 2 && bandcampAlbumData.current.minimum_price === 0)
+                ) {
+                    release.urls.push({
+                        url: release.url,
+                        link_type: link_type.download_for_free,
+                    });
+                }
+                if (bandcampAlbumData.current.download_pref === 2) {
+                    release.urls.push({
+                        url: release.url,
+                        link_type: link_type.purchase_for_download,
+                    });
+                }
+            }
+            // Check if the release is streamable
+            if (bandcampAlbumData.hasAudio && !nostream && disc.tracks.length > 0 && disc.tracks.length == tracks_streamable) {
                 release.urls.push({
                     url: release.url,
-                    link_type: link_type.download_for_free,
+                    link_type: link_type.stream_for_free,
                 });
             }
-            if (bandcampAlbumData.current.download_pref === 2) {
+            // Check if release is Creative Commons licensed
+            const ccIcons = document.querySelector('div#license a.cc-icons');
+            if (ccIcons) {
                 release.urls.push({
-                    url: release.url,
-                    link_type: link_type.purchase_for_download,
+                    url: ccIcons.getAttribute('href').fix_bandcamp_url(),
+                    link_type: link_type.license,
                 });
             }
-        }
-        // Check if the release is streamable
-        if (bandcampAlbumData.hasAudio && !nostream && disc.tracks.length > 0 && disc.tracks.length == tracks_streamable) {
-            release.urls.push({
-                url: release.url,
-                link_type: link_type.stream_for_free,
-            });
-        }
-        // Check if release is Creative Commons licensed
-        const ccIcons = document.querySelector('div#license a.cc-icons');
-        if (ccIcons) {
-            release.urls.push({
-                url: ccIcons.getAttribute('href').fix_bandcamp_url(),
-                link_type: link_type.license,
-            });
         }
         // Check if album has a back link to a label
         let label = this.getlabelname();
@@ -224,22 +256,29 @@ const BandcampImport = {
     },
 
     // Insert links in page
-    insertLink: function (release, isMobile) {
+    insertLink: function (release, isMobile, isPrivateStream) {
         if (release.type == 'track') {
             // only import album or single, tracks belong to an album
             return false;
         }
         // Form parameters
-        const edit_note = MBImport.makeEditNote(release.url, 'Bandcamp');
+        const sourceUrl = isPrivateStream ? `${window.location.origin}${window.location.pathname}` : release.url;
+        const edit_note = isPrivateStream
+            ? MBImport.makeEditNote(sourceUrl, 'Bandcamp', 'private stream')
+            : MBImport.makeEditNote(release.url, 'Bandcamp');
         const parameters = MBImport.buildFormParameters(release, edit_note);
 
         const importButton = MBImport.buildFormHTML(parameters);
         const searchButton = MBImport.buildSearchButton(release);
-        const harmonyButton = MBImport.buildHarmonyButton({
-            barcode: unsafeWindow.TralbumData?.current?.upc || undefined,
-            release_url: release.url,
-            variant: 'full',
-        });
+        const barcode = unsafeWindow.TralbumData?.current?.upc || undefined;
+        const harmonyButton =
+            isPrivateStream && !barcode
+                ? ''
+                : MBImport.buildHarmonyButton({
+                      barcode,
+                      release_url: isPrivateStream ? undefined : release.url,
+                      variant: 'full',
+                  });
 
         // Build form
         const mbUI = document.createElement('div');
@@ -378,6 +417,7 @@ function init() {
     if (!unsafeWindow.TralbumData) return;
     /***/
     const isMobile = typeof unsafeWindow.TralbumJSONLD !== 'undefined';
+    const isPrivateStream = isPrivateStreamPage();
     let mblinks = new MBLinks('BCI_MBLINKS_CACHE');
     const hasBandData = unsafeWindow.BandData && !!unsafeWindow.BandData.id;
     const hasAlbumData = unsafeWindow.TralbumData && 'current' in unsafeWindow.TralbumData; // Sometimes TralbumData is an empty object, see issue #676
@@ -415,10 +455,13 @@ function init() {
     } else if (hasAlbumData) {
         MBImportStyle();
 
-        let release = BandcampImport.retrieveReleaseInfo();
+        let release = BandcampImport.retrieveReleaseInfo(isPrivateStream);
 
         // add MB artist link
-        let root_url = release.url.match(/^(https?:\/\/[^/]+)/)[1].split('?')[0];
+        let root_url = getBandRootUrl();
+        if (!root_url && /^https?:\/\//.test(release.url)) {
+            root_url = release.url.match(/^(https?:\/\/[^/]+)/)[1].split('?')[0];
+        }
         let label_url = '';
 
         mblinks.searchAndDisplayMbLink(
@@ -476,7 +519,7 @@ function init() {
             release.labels[0].mbid = label_mbid;
         }
 
-        BandcampImport.insertLink(release, isMobile);
+        BandcampImport.insertLink(release, isMobile, isPrivateStream);
         LOGGER.info('Parsed release: ', release);
 
         const nameSectionSpans = document.querySelectorAll('div#name-section h3 span');
@@ -495,10 +538,12 @@ function init() {
             mblinks.searchAndDisplayMbLink(root_url, 'artist', function (link) {
                 firstNameSectionSpan?.insertAdjacentHTML('beforebegin', link);
             });
-            // add MB release links to album or single
-            mblinks.searchAndDisplayMbLink(release.url, 'release', function (link) {
-                firstNameSectionSpan?.insertAdjacentHTML('afterend', link);
-            });
+            // add MB release links to album or single (skip for private streams)
+            if (!isPrivateStream) {
+                mblinks.searchAndDisplayMbLink(release.url, 'release', function (link) {
+                    firstNameSectionSpan?.insertAdjacentHTML('afterend', link);
+                });
+            }
         }
 
         // append a comma after each tag to ease cut'n'paste to MB


### PR DESCRIPTION
- example: https://bandcamp.com/private/GP6H33T6, https://bandcamp.com/private/V8QW9SU2;
- the URL relationships will not be added, since it is usually artist's intention to not distribute those URLs widely (per conversaion [here](https://tickets.metabrainz.org/browse/MBS-14350) and [here](https://github.com/murdos/musicbrainz-userscripts/pull/844);
- the Harmony button will only be rendered if a UPC code is detected;
- the status of the release in MB will be set to `Promotion` instead of `Official`;
- the artist detection logic had been augmented to facilitate artist matching on private pages;
- edit note will indicate private streams;
- this PR was born out of https://github.com/murdos/musicbrainz-userscripts/pull/844 (thank you @Jormangeud!), however it supersedes that PR since the necessary changes were not included in the original PR.