### PR TITLE
fix(qobuz_importer): Grab Remix/Remaster Information When Importing

### DIFF
--- a/qobuz_importer.user.js
+++ b/qobuz_importer.user.js
@@ -90,7 +90,10 @@ function parseRelease(data) {
     release.url = `https://www.qobuz.com${data.relative_url}`; // no lang
     release.openQobuzUrl = getOpenQobuzAlbumUrl(data.id);
 
-    release.title = data.title;
+    release.title = data.title.trim();
+    if (data.version) {
+        release.title += ` (${data.version})`;
+    }
     if ($.inArray('Classique', data.genres_list) != -1) {
         is_classical = true;
         release.classical = {};
@@ -169,7 +172,10 @@ function parseRelease(data) {
             tracks = [];
         }
         let track = {};
-        track.title = trackobj.title.replace('"', '"');
+        track.title = trackobj.title.replace('"', '"').trim();
+        if (trackobj.version) {
+            track.title += ` (${trackobj.version})`;
+        }
         track.duration = trackobj.duration * 1000;
         let performers = getPerformers(trackobj);
         if (is_classical) {


### PR DESCRIPTION
Currently, the Qobuz importer script does not grab any extra title information for albums or tracks, making it more time consuming to then import into MB. 

For instance, for "That Acid (The Remixes)" by Marie Vaunt (https://www.qobuz.com/us-en/album/that-acid-marie-vaunt/gcl6bi92qf73b), the data imported looks like this:

> Album Name: That Acid
> Tracks:
> 1. That Acid - Marie Vaunt (2:55)
> 2. That Acid - Marie Vaunt (3:48)
> 3. That Acid - Marie Vaunt (2:51)

instead of this:

> Album: That Acid (The Remixes)
> Tracks:
> 1. That Acid (Dimension & Subsonic Remix) - Marie Vaunt (2:55)
> 2. That Acid (2HOT2PLAY & Jimmy Peel Remix) - Marie Vaunt (3:48)
> 3. That Acid (Yoshiko Remix) - Marie Vaunt (2:51)

This fix grabs the extra information when parsing the release (from the 'version' attribute) and appends it if it's found. 

As part of my testing, I found an album which had a trailing space at the end of its name and so added a call to the string .trim() function when getting the album and track titles as well. 

Example of trailing space: "Hybrid Theory (20th Anniversary Edition)" by Linkin Park (https://www.qobuz.com/us-en/album/hybrid-theory-linkin-park/qzvl42o844ada) has an album title of "Hybrid Theory "