### PR TITLE
feat(bandcamp_importer): query discography links on both page and TralbumData hostnames

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Bandcamp releases to MusicBrainz
 // @description  Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2026.06.06.3
+// @version      2026.06.06.4
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
@@ -90,6 +90,23 @@ const resolveBandcampReleaseUrl = tralbumUrl => {
     }
 
     return result;
+};
+
+/**
+ * Resolve hostnames for discography page lookups from the page location and TralbumData.url.
+ */
+const resolveDiscographyHostnames = tralbumUrl => {
+    const pageHostname = normalizeBandcampUrl(window.location.origin);
+    const tralbumHostname = tralbumUrl ? normalizeBandcampUrl(tralbumUrl.replace(/\/music\/?$/, '').replace(/\/indexpage\/?$/, '')) : '';
+    const hostnames = [pageHostname];
+    if (tralbumHostname && normalizeUrlForComparison(tralbumHostname) !== normalizeUrlForComparison(pageHostname)) {
+        LOGGER.info('TralbumData discography hostname differs from page hostname; looking up both', {
+            pageHostname,
+            tralbumHostname,
+        });
+        hostnames.push(tralbumHostname);
+    }
+    return hostnames;
 };
 
 const BandcampImport = {
@@ -427,33 +444,51 @@ const getHostname = url => {
  * Collects discography release link data from elements matching the given selector.
  * @param {Object} options
  * @param {string} options.linksMatcher - CSS selector for release/track links
- * @param {string} options.hostname - Base hostname for constructing full URLs
+ * @param {string[]} options.hostnames - Base hostnames for constructing full URLs
  * @param {string} [options.insertionLocationMatcher] - Optional selector for insertion point (e.g. 'p.title' for music format)
  * @returns {Array} Array of url_data objects for mblinks.searchAndDisplayMbLinks
  */
-const collectDiscographyReleaseLinks = ({ linksMatcher, hostname, insertionLocationMatcher }) => {
+const collectDiscographyReleaseLinks = ({ linksMatcher, hostnames, insertionLocationMatcher }) => {
     const urls_data = [];
     document.querySelectorAll(linksMatcher).forEach(linkEl => {
         const bandcampReleaseUrl = linkEl.getAttribute('href');
         const pathName = getPathName(bandcampReleaseUrl);
 
         if (pathName && pathName.match(/^(\/album|\/track)/)) {
-            const isRelative = bandcampReleaseUrl.startsWith('/');
-            const linkHostname = isRelative ? hostname : getHostname(bandcampReleaseUrl);
-            const full_url = linkHostname + pathName;
-
-            urls_data.push({
-                url: full_url,
-                mb_type: 'release',
-                insert_func: function (link) {
-                    const target = insertionLocationMatcher ? linkEl.querySelector(insertionLocationMatcher) : linkEl;
-                    if (target) {
-                        target.insertAdjacentHTML('afterbegin', link);
-                    } else {
-                        linkEl.insertAdjacentHTML('afterbegin', link);
+            const lookupUrls = [];
+            if (bandcampReleaseUrl.startsWith('/')) {
+                hostnames.forEach(hostname => {
+                    const full_url = hostname + pathName;
+                    if (!lookupUrls.some(url => normalizeUrlForComparison(url) === normalizeUrlForComparison(full_url))) {
+                        lookupUrls.push(full_url);
                     }
-                },
-                key: `release:${full_url}`,
+                });
+            } else {
+                lookupUrls.push(getHostname(bandcampReleaseUrl) + pathName);
+            }
+
+            const seenReleaseMbids = new Set();
+            const insertReleaseLink = link => {
+                const mb_url = link.match(/href="([^"]+)"/)?.[1];
+                if (!mb_url) return;
+                const mbid = mb_url.slice(-36);
+                if (seenReleaseMbids.has(mbid)) return;
+                seenReleaseMbids.add(mbid);
+                const target = insertionLocationMatcher ? linkEl.querySelector(insertionLocationMatcher) : linkEl;
+                if (target) {
+                    target.insertAdjacentHTML('afterbegin', link);
+                } else {
+                    linkEl.insertAdjacentHTML('afterbegin', link);
+                }
+            };
+
+            lookupUrls.forEach(full_url => {
+                urls_data.push({
+                    url: full_url,
+                    mb_type: 'release',
+                    insert_func: insertReleaseLink,
+                    key: `release:${full_url}`,
+                });
             });
         }
     });
@@ -488,17 +523,17 @@ function init() {
             : unsafeWindow.TralbumData.url.match(/\/indexpage\/?$/)
               ? 'indexpage'
               : null;
-        const hostname = unsafeWindow.TralbumData.url.replace('/music', '').replace('/indexpage', '');
+        const hostnames = resolveDiscographyHostnames(unsafeWindow.TralbumData.url);
         const releaseLinksMatcher = discographyFormat === 'music' ? 'ol#music-grid > li > a' : 'span.indexpage_list div.ipCellLabel1 a';
         const insertionLocationMatcher = discographyFormat === 'music' ? 'p.title' : undefined;
 
         const urls_data = [
             ...collectDiscographyReleaseLinks({
                 linksMatcher: 'ol.featured-grid > li.featured-item > a',
-                hostname,
+                hostnames,
                 insertionLocationMatcher,
             }),
-            ...collectDiscographyReleaseLinks({ linksMatcher: releaseLinksMatcher, hostname, insertionLocationMatcher }),
+            ...collectDiscographyReleaseLinks({ linksMatcher: releaseLinksMatcher, hostnames, insertionLocationMatcher }),
         ];
 
         if (urls_data.length > 0) {


### PR DESCRIPTION
Some Bandcamp artists and labels carry a different base URL in `TralbumData` than the page the user is actually on. That mismatch is often a leftover from when Bandcamp supported whitelabel/custom-domain shops: the discography may be browsed on a `*.bandcamp.com` URL while `TralbumData` still points at a separate shop hostname (e.g. `shop.hammockmusic.com`).

Until now, discography MusicBrainz lookups were built from the TralbumData hostname alone. On those pages that meant we could miss existing MB links that editors had attached to the canonical Bandcamp URL—or to the old shop mirror—depending on which hostname was used in the database.

Look up both hostnames when they differ, and only show one icon per MusicBrainz release when both URLs resolve to the same entry.

Example discography page: https://hammock.bandcamp.com/music