### PR TITLE
fix(bandcamp_importer): namespace artist and label cache keys on discography pages

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -628,7 +628,7 @@ function init() {
 
         if (release.artist_credit.length == 1) {
             // try to get artist's mbid from cache
-            let artist_mbid = mblinks.resolveMBID(root_url);
+            let artist_mbid = mblinks.resolveMBID(`artist:${root_url}`);
             if (artist_mbid) {
                 release.artist_credit[0].mbid = artist_mbid;
             }
@@ -777,7 +777,7 @@ function init() {
             }
         };
 
-        mblinks.searchAndDisplayMbLink(cleanURL, 'artist', insertLinkCb, undefined, onSearchComplete);
+        mblinks.searchAndDisplayMbLink(cleanURL, 'artist', insertLinkCb, `artist:${cleanURL}`, onSearchComplete);
         mblinks.searchAndDisplayMbLink(cleanURL, 'label', insertLinkCb, `label:${cleanURL}`, onSearchComplete);
     }
 }

--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Bandcamp releases to MusicBrainz
 // @description  Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2026.06.07.1
+// @version      2026.06.20
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js

--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -778,7 +778,7 @@ function init() {
         };
 
         mblinks.searchAndDisplayMbLink(cleanURL, 'artist', insertLinkCb, undefined, onSearchComplete);
-        mblinks.searchAndDisplayMbLink(cleanURL, 'label', insertLinkCb, undefined, onSearchComplete);
+        mblinks.searchAndDisplayMbLink(cleanURL, 'label', insertLinkCb, `label:${cleanURL}`, onSearchComplete);
     }
 }
 

--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Bandcamp releases to MusicBrainz
 // @description  Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2026.06.20
+// @version      2026.06.21.1
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
@@ -505,7 +505,7 @@ function init() {
     /***/
     const isMobile = typeof unsafeWindow.TralbumJSONLD !== 'undefined';
     const isPrivateStream = isPrivateStreamPage();
-    let mblinks = new MBLinks('BCI_MBLINKS_CACHE');
+    let mblinks = new MBLinks('BCI_MBLINKS_CACHE', 2);
     const hasBandData = unsafeWindow.BandData && !!unsafeWindow.BandData.id;
     const hasAlbumData = unsafeWindow.TralbumData && 'current' in unsafeWindow.TralbumData; // Sometimes TralbumData is an empty object, see issue #676
     const isDiscographyPage =


### PR DESCRIPTION
_Code and PR written by AI-tool_

## Problem

Fixes #795, #797

On discography/band pages (e.g. `https://hibernate.bandcamp.com`), the script looks up both artist and label relations for the page URL. Both lookups were sharing the same bare URL as their cache key, causing two distinct collision bugs:

1. **Label MBID seeded as artist credit** — when a label was found, its MBID was cached under the bare URL. On subsequent album page visits, `resolveMBID(root_url)` (line 631) would find that cached **label** MBID and incorrectly assign it to `release.artist_credit[0].mbid`, causing MusicBrainz to reject the import with:
   > `Invalid artist_credit.names.0.mbid`

2. **Symmetrical risk** — an artist MBID cached under the bare URL could equally be picked up by a label lookup on a different page visit.

### Evidence from localStorage cache (before fix)

```json
{
    "https://hibernate.bandcamp.com": {
        "urls": ["https://musicbrainz.org/label/ebd021f8-89b9-4363-8977-3751be350572"]
    }
}
```

A **label** MBID stored under the bare URL key — read by `resolveMBID()` as if it were an artist.

## Fix

Namespace both cache keys so artist and label entries are fully disjoint:

```diff
-mblinks.searchAndDisplayMbLink(cleanURL, 'artist', insertLinkCb, undefined, onSearchComplete);
-mblinks.searchAndDisplayMbLink(cleanURL, 'label', insertLinkCb, undefined, onSearchComplete);
+mblinks.searchAndDisplayMbLink(cleanURL, 'artist', insertLinkCb, `artist:${cleanURL}`, onSearchComplete);
+mblinks.searchAndDisplayMbLink(cleanURL, 'label', insertLinkCb, `label:${cleanURL}`, onSearchComplete);
```

The `label:` prefix matches the pattern already used on album pages (line 610). The `artist:` prefix is added symmetrically (as suggested in this PR's review).

The album-page artist MBID resolution is updated to match:

```diff
-let artist_mbid = mblinks.resolveMBID(root_url);
+let artist_mbid = mblinks.resolveMBID(`artist:${root_url}`);
```

### Cache after fix

```json
{
    "artist:https://hibernate.bandcamp.com": { "urls": [] },
    "label:https://hibernate.bandcamp.com": {
        "urls": ["https://musicbrainz.org/label/ebd021f8-89b9-4363-8977-3751be350572"]
    }
}
```

Label MBID is namespaced. `resolveMBID(`artist:${root_url}`)` correctly finds nothing (empty artist result), so no bogus MBID is seeded into the artist credit.

## Testing

Tested on https://hibernate.bandcamp.com/album/the-state-of-shining (the example from #795). After clearing the localStorage cache and revisiting the page, the import button works correctly without the `Invalid artist_credit` error.
