### PR TITLE
fix(encyclopedisque_importer): allow script to run on https

### DIFF
--- a/encyclopedisque_importer.user.js
+++ b/encyclopedisque_importer.user.js
@@ -1,12 +1,12 @@
 ﻿// ==UserScript==
 // @name         Import Encyclopedisque releases to MusicBrainz
-// @version      2026.05.31.1
+// @version      2026.06.21.1
 // @namespace    http://userscripts.org/users/22504
 // @description  Easily import Encyclopedisque releases into MusicBrainz
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/encyclopedisque_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/encyclopedisque_importer.user.js
-// @include      http://www.encyclopedisque.fr/disque/*.html
-// @include      http://www.encyclopedisque.fr/artiste/*.html
+// @include      https://www.encyclopedisque.fr/disque/*.html
+// @include      https://www.encyclopedisque.fr/artiste/*.html
 // @require      https://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js
 // @require      lib/mbimport.js
 // @require      lib/mblinks.js?version=v2026.05.31.1


### PR DESCRIPTION
- the website seems to only be supported with https for a number of years now. Since no one reported this for so many years, I assume this script is not used by anyone. Yet, the Encyclopedisque database exists and even seems to be populated at times.