### PR TITLE
chore: restrict fresh packages from being installed to reduce risk of supply chain attacks

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 onlyBuiltDependencies:
   - esbuild
+minimumReleaseAge: 4320 # 3 days


### PR DESCRIPTION
- pnpm will allow to install a specific version of a dependency only if it's at least 3 days old