### PR TITLE
chore: introduce oxlint

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,6 +20,8 @@ jobs:
         run: pnpm format:check
       - name: 'Run type checking'
         run: pnpm type-check
+      - name: 'Run oxlint'
+        run: pnpm oxlint
       - name: 'Run linter'
         run: pnpm lint
       - name: 'Build userscripts'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,13 @@
         "source.removeUnusedImports": "always"
     },
     "typescript.preferences.preferTypeOnlyAutoImports": true,
-    "js/ts.preferences.preferTypeOnlyAutoImports": true
+    "js/ts.preferences.preferTypeOnlyAutoImports": true,
+    "typescript.experimental.useTsgo": true,
+    "js/ts.experimental.useTsgo": true,
+    "[typescript]": {
+        "editor.defaultFormatter": "oxc.oxc-vscode"
+    },
+    "[javascript]": {
+        "editor.defaultFormatter": "oxc.oxc-vscode"
+    }
 }

--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -743,7 +743,7 @@ function init() {
             }
         };
 
-        function showLookupButtonsIfNoLink() {
+        const showLookupButtonsIfNoLink = function () {
             if (!isLinkInserted) {
                 MBSearchItStyle();
                 const entityName = unsafeWindow.BandData.name;

--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -19,8 +19,10 @@
 // @run-at       document-start
 // ==/UserScript==
 
-// eslint-disable-next-line no-global-assign
-if (!unsafeWindow) unsafeWindow = window;
+/* oxlint-disable-next-line no-global-assign */
+if (!unsafeWindow) {
+    unsafeWindow = window;
+}
 
 String.prototype.fix_bandcamp_url = function () {
     let url = this;
@@ -772,7 +774,7 @@ function init() {
                     </span>`,
                 );
             }
-        }
+        };
 
         // The URL could either be a band or a label page, we don't know which, so we search for both.
         // Show lookup buttons only after both searches have completed and neither found a link.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,15 +62,15 @@ export default defineConfig([
         },
 
         rules: {
-            'prefer-template': 'error',
-            'no-inner-declarations': 'warn',
-            'no-global-assign': 'warn',
-            'no-redeclare': 'warn',
-            'no-self-assign': 'warn',
+            'prefer-template': 'off', // migrated to oxlint
+            'no-inner-declarations': 'off', // migrated to oxlint
+            'no-global-assign': 'off', // migrated to oxlint
+            'no-redeclare': 'off', // migrated to oxlint
+            'no-self-assign': 'off', // migrated to oxlint
             'no-undef': 'warn',
-            'no-useless-concat': 'warn',
-            'no-useless-escape': 'warn',
-            'no-var': 'warn',
+            'no-useless-concat': 'off', // migrated to oxlint
+            'no-useless-escape': 'off', // migrated to oxlint
+            'no-var': 'off', // migrated to oxlint
         },
     },
 ]);

--- a/fma_importer.user.js
+++ b/fma_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import FMA releases to MusicBrainz
 // @description  Add a button to import https://freemusicarchive.org/ releases to MusicBrainz via API
-// @version      2026.05.31.1
+// @version      2026.06.21.1
 // @namespace    https://github.com/murdos/musicbrainz-userscripts
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/fma_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/fma_importer.user.js
@@ -483,14 +483,10 @@ function parse_MM_DD_YYYY(date, obj) {
 function Parsefmarelease(albumobject, trackobject) {
     if (albumobject === undefined) {
         albumobject = [];
-    } else {
-        albumobject = albumobject;
     }
 
     if (trackobject === undefined) {
         trackobject = [];
-    } else {
-        trackobject = trackobject;
     }
 
     let fmarelease = {};

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -33,7 +33,7 @@ const LOGGER = (function () {
         args.unshift(`[${level}]`);
         try {
             console.log.apply(this, args);
-        } catch (e) {
+        } catch {
             // do nothing
         }
     }

--- a/loot_importer.user.js
+++ b/loot_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Loot releases to MusicBrainz
 // @description  Add a button to import Loot.co.za releases to MusicBrainz
-// @version      2026.05.31.1
+// @version      2026.06.21.1
 // @namespace    https://github.com/murdos/musicbrainz-userscripts
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/loot_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/loot_importer.user.js
@@ -267,7 +267,7 @@ function ParseLootPage() {
 
             let currenttrack = element.querySelectorAll('td');
             //   var artisttitle_regex = /(.*) - (.*)/; // regex: artist - title
-            var artisttitle_regex = /(.*) (-|–) (.*)/; // regex: artist - title char 45 or 8211
+            const artisttitle_regex = /(.*) (-|–) (.*)/; // regex: artist - title char 45 or 8211
 
             // need to check if this can be replaced with single regex for now check artist-title if
             // not matching check just title
@@ -276,7 +276,7 @@ function ParseLootPage() {
                 descriptiontrack.title = artisttitle[3];
                 descriptiontrack.artist = artisttitle[1];
             } else {
-                var title_regex = /(.*)/; // regex: title
+                const title_regex = /(.*)/; // regex: title
                 const artisttitle = currenttrack[1].innerText.match(title_regex);
                 descriptiontrack.title = artisttitle[1];
                 descriptiontrack.artist = releaseartist;
@@ -383,10 +383,10 @@ function ParseLootPage() {
 //                                   Loot -> MusicBrainz mapping                                                  //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-var Languages = new Array();
+const Languages = new Array();
 Languages['Afrikaans'] = 'afr';
 
-var Countries = new Array();
+const Countries = new Array();
 Countries['Afghanistan'] = 'AF';
 Countries['Albania'] = 'AL';
 Countries['Algeria'] = 'DZ';

--- a/loot_importer.user.js
+++ b/loot_importer.user.js
@@ -276,8 +276,8 @@ function ParseLootPage() {
                 descriptiontrack.title = artisttitle[3];
                 descriptiontrack.artist = artisttitle[1];
             } else {
-                var artisttitle_regex = /(.*)/; // regex: title
-                const artisttitle = currenttrack[1].innerText.match(artisttitle_regex);
+                var title_regex = /(.*)/; // regex: title
+                const artisttitle = currenttrack[1].innerText.match(title_regex);
                 descriptiontrack.title = artisttitle[1];
                 descriptiontrack.artist = releaseartist;
             }

--- a/mb_discids_detector.user.js
+++ b/mb_discids_detector.user.js
@@ -296,13 +296,13 @@ const MBDiscid = (function () {
         }
 
         for (let i = 0; i < discs.length; i++) {
-            var entries = discs[i];
-            let layout_type = get_layout_type(entries);
+            var discEntries = discs[i];
+            let layout_type = get_layout_type(discEntries);
             let entries_audio;
             if (layout_type === 'with_data') {
-                entries_audio = entries.slice(0, entries.length - 1);
+                entries_audio = discEntries.slice(0, discEntries.length - 1);
             } else {
-                entries_audio = entries;
+                entries_audio = discEntries;
             }
             discs[i] = entries_audio;
         }

--- a/mb_discids_detector.user.js
+++ b/mb_discids_detector.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Musicbrainz DiscIds Detector
 // @namespace    http://userscripts.org/users/22504
-// @version      2024.11.26.1
+// @version      2026.06.21.1
 // @description  Generate MusicBrainz DiscIds from online EAC logs, and check existence in MusicBrainz database.
 // @downloadURL  https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/mb_discids_detector.user.js
 // @updateURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/mb_discids_detector.user.js
@@ -277,7 +277,7 @@ const MBDiscid = (function () {
     );
     this.log_input_to_entries = function (text) {
         let discs = [];
-        var entries = [];
+        let entries = [];
         $.each(text.split('\n'), function (index, value) {
             let m = toc_entry_matcher.exec(value);
             if (m) {
@@ -296,7 +296,7 @@ const MBDiscid = (function () {
         }
 
         for (let i = 0; i < discs.length; i++) {
-            var discEntries = discs[i];
+            const discEntries = discs[i];
             let layout_type = get_layout_type(discEntries);
             let entries_audio;
             if (layout_type === 'with_data') {

--- a/mb_relationship_shortcuts.user.js
+++ b/mb_relationship_shortcuts.user.js
@@ -169,7 +169,10 @@ background-image: url(https://store.steampowered.com/favicon.ico);
 background-size: 16px;
 }`;
 
-if (!unsafeWindow) unsafeWindow = window;
+/* oxlint-disable-next-line no-global-assign */
+if (!unsafeWindow) {
+    unsafeWindow = window;
+}
 
 function init() {
     // Get pageType (label or artist)

--- a/mb_ui_enhancements.user.js
+++ b/mb_ui_enhancements.user.js
@@ -413,7 +413,7 @@ $(document).ready(function () {
                         .find(`td:nth-last-child(${ISRC_COLUMN_POSITION})`)
                         .before(`<td class='isrc c'><small>${isrcsLinks}</small></td>`);
                 });
-            }
+            };
         }
     }
 

--- a/mb_ui_enhancements.user.js
+++ b/mb_ui_enhancements.user.js
@@ -375,7 +375,7 @@ $(document).ready(function () {
                 }
             });
 
-            function handleMedium($medium, ws_tracks) {
+            const handleMedium = function ($medium, ws_tracks) {
                 // Extend colspan for medium table header
                 $medium.find('thead tr').each(function () {
                     $(this)

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -21,9 +21,6 @@ export default defineConfig({
         es6: true,
         node: true,
     },
-    globals: {
-        unsafeWindow: 'writable',
-    },
     overrides: [
         {
             files: ['**/*.user.js'],

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1,0 +1,51 @@
+import { defineConfig } from 'oxlint';
+
+export default defineConfig({
+    plugins: ['eslint', 'typescript', 'node', 'oxc', 'import'],
+    options: {
+        typeAware: true,
+    },
+    categories: {
+        correctness: 'off',
+        suspicious: 'off',
+        style: 'off',
+        perf: 'off',
+        pedantic: 'off',
+        restriction: 'off',
+        nursery: 'off',
+    },
+    env: {
+        browser: true,
+        greasemonkey: true,
+        jquery: true,
+        es6: true,
+        node: true,
+    },
+    globals: {
+        unsafeWindow: 'writable',
+    },
+    overrides: [
+        {
+            files: ['**/*.user.js'],
+            globals: {
+                LOGGER: 'readonly',
+                MBImportStyle: 'readonly',
+                MBImport: 'readonly',
+                MBLinks: 'readonly',
+                MBSearchItStyle: 'readonly',
+            },
+        },
+    ],
+    rules: {
+        'prefer-template': 'error',
+        'no-inner-declarations': 'warn',
+        'no-global-assign': 'warn',
+        'no-redeclare': 'warn',
+        'no-self-assign': 'warn',
+        // 'no-undef': 'warn', // TODO: Too many odd issues to fix, will be addressed later
+        'no-useless-concat': 'warn',
+        'no-useless-escape': 'warn',
+        'no-var': 'warn',
+    },
+    ignorePatterns: ['node_modules/**', '.git/**'],
+});

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "format:check": "oxfmt --check",
         "lint": "pnpm run eslint",
         "lint-fix": "pnpm run eslint -- --fix",
+        "oxlint": "oxlint --type-aware",
         "eslint": "eslint .",
         "test": "node --strip-types tests/discogs/run.ts",
         "test:discogs": "node --strip-types tests/discogs/run.ts",
@@ -53,6 +54,8 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.2.4",
         "oxfmt": "^0.55.0",
+        "oxlint": "^1.70.0",
+        "oxlint-tsgolint": "^0.23.0",
         "rollup": "^4.62.0",
         "typescript-eslint": "^8.46.1",
         "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,12 @@ importers:
       oxfmt:
         specifier: ^0.55.0
         version: 0.55.0
+      oxlint:
+        specifier: ^1.70.0
+        version: 1.70.0(oxlint-tsgolint@0.23.0)
+      oxlint-tsgolint:
+        specifier: ^0.23.0
+        version: 0.23.0
       rollup:
         specifier: ^4.62.0
         version: 4.62.0
@@ -798,6 +804,158 @@ packages:
 
   '@oxfmt/binding-win32-x64-msvc@0.55.0':
     resolution: {integrity: sha512-eEYT5tivGnGbPHuOHuQpi6CGLObhh0re/5jcNQHihD2GRYkTM85dyi5a19zjP8Q00t1uqAx+/QGLUGdHeqzWyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint-tsgolint/darwin-arm64@0.23.0':
+    resolution: {integrity: sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@0.23.0':
+    resolution: {integrity: sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@0.23.0':
+    resolution: {integrity: sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@0.23.0':
+    resolution: {integrity: sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@0.23.0':
+    resolution: {integrity: sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@0.23.0':
+    resolution: {integrity: sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.70.0':
+    resolution: {integrity: sha512-zFh0P4cswmRvw6nkyb89dr18rRanuaCPAsEXsFDoQY8WdaquI8Pt4NWFjaMJg6L23cy5NeN8J9cBnREbWzZhaw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.70.0':
+    resolution: {integrity: sha512-qI8o4HZjeGiBrWv+pJv4lH0Yi2Gl/JSp/EumBUApezJprIKa5PS4nU0lQsQngtky8k+SplQIOjv6hwu0SSxeyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.70.0':
+    resolution: {integrity: sha512-8KjgVVHI5F9nVwHCRwwA78Ty7zNKP4Wd9OeN5PSv3iu/F/u1RVXoOCgLhWqust6HmwQG6xc8c+RCyaWENy24+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.70.0':
+    resolution: {integrity: sha512-WVydssv5PSUBXFJTdNBWlmGkbNmvPGaFt/2SUT/EZRB6bq6bEOHmMlbnupZD5jmlEvi9+mZJHi8TCw15lyfSfQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.70.0':
+    resolution: {integrity: sha512-hJucmUf8OlinHNb1R7fI4Fw6WsAstOz7i8nmkWQfiHoZXtbufNm+MxiDTIMk1ggh2Ro4vLzgQ+bKvRY54MZoRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.70.0':
+    resolution: {integrity: sha512-1BnS7wbCYDSXwWzJJ+mc3NURoha6m6m6RT5c6vgAY3oz7C3OVXP+S0awo2mRq97arrJkVvO3qRQfyAHL+76xtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.70.0':
+    resolution: {integrity: sha512-yKy/UdbR55+M2yEcuiV5DCNC/gdQAjr/GioUy50QwBzSrKm8ueWADqyRLS9Xk+qjNeCYGg6A8FvUBds56ttfqg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.70.0':
+    resolution: {integrity: sha512-0A5XJ4alvmqFUFP/4oYSyaO+qLto/HrKEWTSaegiVl+HOufFngK2BjYw9x4RbwBt/du5QG6l5q1zeWiJYYG5yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.70.0':
+    resolution: {integrity: sha512-JiylyurlB0CLSedNtx1gzv3FvfWPF1h/2Y3BJszPLNt5XQFlBsH5ke0Jle3iJb3uqu5m2e7A/DwzpuCAHdiU+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.70.0':
+    resolution: {integrity: sha512-J8VPG7I3/HmgaU4u8pNU2kFx2+0U+vPLS1dXFxXOaR/2TQ0f8AC7DRz0SRGRI1bfphnX2hVYTTtLuhL4nYKL+Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.70.0':
+    resolution: {integrity: sha512-N2+4lV2KLN+oXTIIIwmWDhwkrnvqf5oX7Hw0zPjk+RuIVgiBQSOlJWF7uQoFx2siEYX0ZQ5cfSbEAHm+J3t7Wg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.70.0':
+    resolution: {integrity: sha512-1e2L7cFCvx9QDzq6NPP+0tABKb5z6nWHyddWTNKprEsjO9xNrAtPowuCGpjNXxkTdsMiZ4jc8YQ5SstZd4XK6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.70.0':
+    resolution: {integrity: sha512-Kwu/l/8GcYibCWA9m9N5pRXMIKVSsL/YbgpLzYkqDhWTiqdRfnNJ/+nqIKRKQiFbHWsdlHEhzMwruJK+qcEruA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.70.0':
+    resolution: {integrity: sha512-tap04CsHYOl0nSAQJfPNIuBxqEPB2HnhQqwaOXLg1jnp2XfRo8Fa814dA4QC4zpvTWXCjAAaCY1W5LOORkEQuQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.70.0':
+    resolution: {integrity: sha512-hzJa/WgvtJpbBD9rgfy0qe+MjbxOXNUT0bfR1S6EQQzfTtBFA9xg5q8KSwRrQ2QfSS+TaP4j+4mVPQrfNc6UNg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.70.0':
+    resolution: {integrity: sha512-xbsaNSNzVSnaJACCUYr1HQMyY/Q/Q1LkePmHG3UvZPvGCYGNxrsZp9OmtA6ick8xH47ltRRbRrPCM1YXYcyC+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.70.0':
+    resolution: {integrity: sha512-icAEsUI7JbW1TMRdEXV83mVAInhRVQYuuAlPpxdGwJ95chNdnCzjloRW8GglT0WvzOEZSio6fnYSk2DJ2Hv7LQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.70.0':
+    resolution: {integrity: sha512-FHMSWbVsPVs/f+Jcl04ws4JJ2wUnauyTzlpxWRG/lSO/8GpX08Fo2gQZqdA6CrRFI+zvkxl+N/KwJGWfUwYVZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.70.0':
+    resolution: {integrity: sha512-ptOlKwCz7n4AKs5VweMqG6DAg677FmKOK+vBkkL9DMNgFATIQ+upqUYBTOEwRQyRAx1ncGlPlXleV2hIcm3z4g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1889,6 +2047,23 @@ packages:
       vite-plus: '*'
     peerDependenciesMeta:
       svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
+  oxlint-tsgolint@0.23.0:
+    resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
+    hasBin: true
+
+  oxlint@1.70.0:
+    resolution: {integrity: sha512-D6JgHtzkhRwvEC+A0Nw5AEc5bk8x5i1pHzvZIEf/a0C4hOzmAACNGtkDGPyFaxxX3ZVGxCPeig3P3rMM8XU3/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
         optional: true
       vite-plus:
         optional: true
@@ -3007,6 +3182,81 @@ snapshots:
     optional: true
 
   '@oxfmt/binding-win32-x64-msvc@0.55.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-arm64@0.23.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@0.23.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@0.23.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@0.23.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@0.23.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@0.23.0':
+    optional: true
+
+  '@oxlint/binding-android-arm-eabi@1.70.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.70.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.70.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.70.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.70.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.70.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.70.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.70.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.70.0':
     optional: true
 
   '@rollup/plugin-alias@6.0.0(rollup@4.62.0)':
@@ -4143,6 +4393,38 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.55.0
       '@oxfmt/binding-win32-ia32-msvc': 0.55.0
       '@oxfmt/binding-win32-x64-msvc': 0.55.0
+
+  oxlint-tsgolint@0.23.0:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 0.23.0
+      '@oxlint-tsgolint/darwin-x64': 0.23.0
+      '@oxlint-tsgolint/linux-arm64': 0.23.0
+      '@oxlint-tsgolint/linux-x64': 0.23.0
+      '@oxlint-tsgolint/win32-arm64': 0.23.0
+      '@oxlint-tsgolint/win32-x64': 0.23.0
+
+  oxlint@1.70.0(oxlint-tsgolint@0.23.0):
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.70.0
+      '@oxlint/binding-android-arm64': 1.70.0
+      '@oxlint/binding-darwin-arm64': 1.70.0
+      '@oxlint/binding-darwin-x64': 1.70.0
+      '@oxlint/binding-freebsd-x64': 1.70.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.70.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.70.0
+      '@oxlint/binding-linux-arm64-gnu': 1.70.0
+      '@oxlint/binding-linux-arm64-musl': 1.70.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.70.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.70.0
+      '@oxlint/binding-linux-riscv64-musl': 1.70.0
+      '@oxlint/binding-linux-s390x-gnu': 1.70.0
+      '@oxlint/binding-linux-x64-gnu': 1.70.0
+      '@oxlint/binding-linux-x64-musl': 1.70.0
+      '@oxlint/binding-openharmony-arm64': 1.70.0
+      '@oxlint/binding-win32-arm64-msvc': 1.70.0
+      '@oxlint/binding-win32-ia32-msvc': 1.70.0
+      '@oxlint/binding-win32-x64-msvc': 1.70.0
+      oxlint-tsgolint: 0.23.0
 
   p-limit@3.1.0:
     dependencies:

--- a/takealot_importer.user.js
+++ b/takealot_importer.user.js
@@ -477,8 +477,6 @@ function parse_YYYY_MM_DD(date, obj) {
 function Parsefmarelease(albumobject, trackobject) {
     if (albumobject === undefined) {
         albumobject = [];
-    } else {
-        albumobject = albumobject;
     }
 
     let fmarelease = {};

--- a/takealot_importer.user.js
+++ b/takealot_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Takealot releases to MusicBrainz
 // @description  Add a button to import https://www.takealot.com/ releases to MusicBrainz via API
-// @version      2026.05.31.1
+// @version      2026.06.21.1
 // @namespace    https://github.com/murdos/musicbrainz-userscripts
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/takealot_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/takealot_importer.user.js
@@ -391,14 +391,14 @@ function parseFMApage() {
             LOGGER.debug('Uhm I think the idProduct is missing folks and comments left ...');
             let FMAEmbedCode = $('div.cell:nth-child(3) > a:nth-child(1)').attr('href');
             LOGGER.debug('The album id for API: ', FMAEmbedCode);
-            FMAEmbedCodeRegex = /product_id\=(\d*)/;
+            FMAEmbedCodeRegex = /product_id=(\d*)/;
             let FMAAlbumIdMatch = FMAEmbedCode.match(FMAEmbedCodeRegex); // match the Id
             release_attributes.albumid = FMAAlbumIdMatch[1]; // assign the ID to a variable
         } else if (typeof $('#idProduct').attr('value') === 'undefined' && $('.reviews > a:nth-child(1)').length) {
             LOGGER.debug('Uhm I think the idProduct is missing folks ...');
             let FMAEmbedCode = $('.reviews > a:nth-child(1)').attr('href');
             LOGGER.debug('The album id for API: ', FMAEmbedCode);
-            FMAEmbedCodeRegex = /product_id\=(\d*)/;
+            FMAEmbedCodeRegex = /product_id=(\d*)/;
             let FMAAlbumIdMatch = FMAEmbedCode.match(FMAEmbedCodeRegex); // match the Id
             release_attributes.albumid = FMAAlbumIdMatch[1]; // assign the ID to a variable
         } else {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,7 @@
         },
         "types": ["node"]
     },
-    "include": ["src/**/*", "tests/**/*", "oxfmt.config.ts"],
+    "include": ["src/**/*", "tests/**/*", "oxfmt.config.ts", "oxlint.config.ts"],
     "typeRoots": ["node_modules/@types", "src/types"],
     "exclude": ["node_modules", "dist", "**/*.user.js"]
 }


### PR DESCRIPTION
- migrate a few initial hardcoded rules to oxlint and address issues that eslint for some reason didn't catch;
- enable oxlint checks in the CI;
- force vscode to use tsgo and explicitly spell out oxc as a default formatter for typescript (for some reason it wasn't inferring it correctly for all files).