### PR TITLE
feat(future_release_annotation): add the new `MusicBrainz: Future release annotation` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [MusicBrainz: Batch-add "performance of" relationships](#batch-add-recording-relationships)
 - [MusicBrainz: Expand/collapse release groups](#expand-collapse-release-groups)
 - [MusicBrainz: Fast cancel edits](#fast-cancel-edits)
+- [<img src="assets/icons/typescript.svg" alt="TypeScript" width="16" height="16"> MusicBrainz: Future release annotation](#future_release_annotation)
 - [MusicBrainz: Set recording comments for a release](#set-recording-comments)
 - [Musicbrainz DiscIds Detector](#mb_discids_detector)
 - [Musicbrainz UI enhancements](#mb_ui_enhancements)
@@ -187,6 +188,13 @@ Mass cancel open edits with optional edit notes.
 
 [![Source](assets/buttons/button-source.svg)](https://github.com/murdos/musicbrainz-userscripts/blob/master/fast-cancel-edits.user.js)
 [![Install](assets/buttons/button-install.svg)](https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/fast-cancel-edits.user.js)
+
+## <a name="future_release_annotation"></a> <img src="assets/icons/typescript.svg" alt="TypeScript" width="16" height="16"> MusicBrainz: Future release annotation
+
+Adds an annotation note when importing a release with a future release date on the release editor. The annotation note serves as a reminder to verify the release info when it is released.
+
+[![Source](assets/buttons/button-source.svg)](https://github.com/murdos/musicbrainz-userscripts/blob/dist/future_release_annotation.user.js)
+[![Install](assets/buttons/button-install.svg)](https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/future_release_annotation.user.js)
 
 ## <a name="set-recording-comments"></a> MusicBrainz: Set recording comments for a release
 

--- a/src/types/musicbrainz.d.ts
+++ b/src/types/musicbrainz.d.ts
@@ -1,0 +1,40 @@
+/** Partial MusicBrainz release editor types used by userscripts. */
+
+export interface MBPartialDate {
+    /** Empty string when not populated. */
+    year: () => string;
+    /** Number when populated, empty string otherwise. */
+    month: () => number | string;
+    /** Number when populated, empty string otherwise. */
+    day: () => number | string;
+}
+
+export interface MBReleaseEvent {
+    date: MBPartialDate;
+}
+
+export interface MBRelease {
+    annotation: {
+        (): string;
+        (value: string): void;
+    };
+    events: () => MBReleaseEvent[];
+}
+
+export interface MBReleaseEditor {
+    rootField: {
+        release: () => MBRelease | null | undefined;
+    };
+}
+
+export interface MusicBrainz {
+    releaseEditor: MBReleaseEditor;
+}
+
+declare global {
+    interface Window {
+        MB?: MusicBrainz;
+    }
+}
+
+export {};

--- a/src/userscripts/future_release_annotation/index.ts
+++ b/src/userscripts/future_release_annotation/index.ts
@@ -1,0 +1,136 @@
+import { Logger, LogLevel } from '~/lib/logger';
+import type { MBRelease, MBReleaseEvent } from '~/types/musicbrainz';
+
+import { isFutureRelease } from './partial-date';
+
+const LOGGER = new Logger('future_release_annotation', LogLevel.INFO);
+
+const ANNOTATION_NOTE =
+    'Note: this release was imported before the official release, after it is released please verify all info and then remove this note.';
+
+const POLL_INTERVAL_MS = 500;
+const MB_WAIT_INTERVAL_MS = 200;
+const MAX_POLLS = 20;
+
+function isReleaseAddPage(): boolean {
+    return window.location.pathname === '/release/add';
+}
+
+function getRelease(): MBRelease | null {
+    const release = window.MB?.releaseEditor.rootField.release();
+    return release ?? null;
+}
+
+function getReleaseEventDates(events: MBReleaseEvent[]) {
+    return events.map(event => ({
+        year: event.date.year(),
+        month: event.date.month(),
+        day: event.date.day(),
+    }));
+}
+
+function prependAnnotationNote(currentAnnotation: string): string {
+    if (currentAnnotation.includes(ANNOTATION_NOTE)) {
+        return currentAnnotation;
+    }
+
+    LOGGER.info('Updated annotation note');
+
+    const trimmed = currentAnnotation.trim();
+    return trimmed ? `${ANNOTATION_NOTE}\n\n${trimmed}` : ANNOTATION_NOTE;
+}
+
+function buildStateFingerprint(release: MBRelease): string {
+    const dates = getReleaseEventDates(release.events());
+    return JSON.stringify({
+        annotation: release.annotation(),
+        dates,
+    });
+}
+
+function updateAnnotationIfNeeded(): void {
+    if (!isReleaseAddPage()) {
+        LOGGER.debug('Not on release add page, skipping');
+        return;
+    }
+
+    const release = getRelease();
+    if (!release) {
+        LOGGER.debug('No release found, skipping');
+        return;
+    }
+
+    const eventDates = getReleaseEventDates(release.events());
+    if (!isFutureRelease(eventDates)) {
+        LOGGER.debug('Release event dates are not in the future, skipping');
+        return;
+    }
+
+    const currentAnnotation = release.annotation();
+    const updatedAnnotation = prependAnnotationNote(currentAnnotation);
+    if (updatedAnnotation !== currentAnnotation) {
+        release.annotation(updatedAnnotation);
+        LOGGER.debug('Added future release annotation note');
+    }
+}
+
+function waitForReleaseEditor(): Promise<boolean> {
+    return new Promise(resolve => {
+        let attempts = 0;
+        const check = () => {
+            LOGGER.debug('Checking for release editor');
+            if (getRelease()) {
+                LOGGER.debug('Release editor found');
+                resolve(true);
+                return;
+            }
+            attempts++;
+            if (attempts >= MAX_POLLS) {
+                LOGGER.debug('Release editor not found after max polls, giving up');
+                resolve(false);
+                return;
+            }
+            window.setTimeout(check, MB_WAIT_INTERVAL_MS);
+        };
+        check();
+    });
+}
+
+function startWatching(): void {
+    let lastFingerprint = '';
+
+    window.setInterval(() => {
+        if (!isReleaseAddPage()) {
+            return;
+        }
+
+        const release = getRelease();
+        if (!release) {
+            return;
+        }
+
+        const fingerprint = buildStateFingerprint(release);
+        if (fingerprint !== lastFingerprint) {
+            lastFingerprint = fingerprint;
+            updateAnnotationIfNeeded();
+        }
+    }, POLL_INTERVAL_MS);
+}
+
+async function init(): Promise<void> {
+    LOGGER.debug('Initializing future release annotation');
+    if (!isReleaseAddPage()) {
+        return;
+    }
+
+    LOGGER.debug('Waiting for release editor');
+    const releaseEditorFound = await waitForReleaseEditor();
+    if (releaseEditorFound) {
+        LOGGER.debug('Updating annotation if needed');
+        updateAnnotationIfNeeded();
+    }
+    LOGGER.debug('Starting to watch for changes');
+    startWatching();
+}
+
+void init();

--- a/src/userscripts/future_release_annotation/meta.json
+++ b/src/userscripts/future_release_annotation/meta.json
@@ -1,0 +1,18 @@
+{
+    "name": "MusicBrainz: Future release annotation",
+    "description": "Adds an annotation note when importing a release with a future release date on the release editor. The annotation note serves as a reminder to verify the release info when it is released.",
+    "version": "2026.06.23.1",
+    "author": "Raman Sinclair",
+    "namespace": "https://github.com/murdos/musicbrainz-userscripts/",
+    "downloadURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/future_release_annotation.user.js",
+    "updateURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/future_release_annotation.user.js",
+    "match": [
+        "https://musicbrainz.org/release/add*",
+        "https://beta.musicbrainz.org/release/add*",
+        "https://eu.musicbrainz.org/release/add*",
+        "https://test.musicbrainz.org/release/add*"
+    ],
+    "grant": ["none"],
+    "runAt": "document-start",
+    "icon": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png"
+}

--- a/src/userscripts/future_release_annotation/partial-date.ts
+++ b/src/userscripts/future_release_annotation/partial-date.ts
@@ -1,0 +1,71 @@
+function parsePart(value: number | string): number | null {
+    if (value === '') {
+        return null;
+    }
+    const parsed = typeof value === 'string' ? Number.parseInt(value, 10) : value;
+    if (Number.isNaN(parsed) || parsed <= 0) {
+        return null;
+    }
+    return parsed;
+}
+
+interface MbPartialDateInput {
+    year: string;
+    month: number | string;
+    day: number | string;
+}
+
+interface IsEventDateInFutureParams {
+    event: MbPartialDateInput;
+    today: Date;
+}
+
+/** True when a MB partial date is strictly after today; false when unset or not in the future. */
+export function isEventDateInFuture({ event, today }: IsEventDateInFutureParams): boolean {
+    const { year, month, day } = event;
+    const y = parsePart(year);
+    if (y === null) {
+        return false;
+    }
+
+    const todayYear = today.getFullYear();
+    if (y > todayYear) {
+        return true;
+    }
+    if (y < todayYear) {
+        return false;
+    }
+
+    const m = parsePart(month);
+    if (m === null) {
+        return false;
+    }
+
+    const todayMonth = today.getMonth() + 1;
+    if (m > todayMonth) {
+        return true;
+    }
+    if (m < todayMonth) {
+        return false;
+    }
+
+    const d = parsePart(day);
+    if (d === null) {
+        return false;
+    }
+
+    return d > today.getDate();
+}
+
+/** True when every dated release event is strictly after today. */
+export function isFutureRelease(events: MbPartialDateInput[]): boolean {
+    const fullyDatedEvents = events.filter(event => event.year !== '' && event.month !== '' && event.day !== '');
+
+    if (fullyDatedEvents.length === 0) {
+        return false;
+    }
+
+    const today = new Date();
+
+    return fullyDatedEvents.every(event => isEventDateInFuture({ event, today }));
+}


### PR DESCRIPTION
## Summary

Adds a new TypeScript userscript, **MusicBrainz: Future release annotation**, for the release editor (`/release/add` on musicbrainz.org, beta, eu, and test).

When a release is imported with a **future release date**, the script automatically prepends a reminder to the annotation field:

> Note: this release was imported before the official release, after it is released please verify all info and then remove this note.

If there is already annotation text, the note is added above it, separated by a blank line. If the note is already present, nothing is changed.

## Why

Pre-release imports are common when adding releases from digital stores before their official date. Tracklists, credits, barcodes, and other metadata can still change before release day. Without a visible marker, it is easy for editors (and later reviewers) to miss that the entry was created early and may need a follow-up check.

This script adds that marker automatically at import time, so future editors know the release should be re-verified once it is actually out.

## How it works

- Runs on `/release/add` pages and uses the internal `MB.releaseEditor.rootField.release()` object to get the release data
- Checks all release events; a release is treated as future only when every dated event has a full year/month/day and all of them are strictly after today
- Waits briefly for the MB editor to initialize after page load, then also keeps watching for manual date/annotation changes in the editor
- Uses `@grant none` to run in page context and access the `MB` object directly

Also adds shared `MB` release editor types in `src/types/musicbrainz.d.ts` for reuse by other scripts.