### PR TITLE
chore: combine eslint & oxlint within one script

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,8 +20,6 @@ jobs:
         run: pnpm format:check
       - name: 'Run type checking'
         run: pnpm type-check
-      - name: 'Run oxlint'
-        run: pnpm oxlint
       - name: 'Run linter'
         run: pnpm lint
       - name: 'Build userscripts'

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "type-check": "tsgo",
         "format": "oxfmt",
         "format:check": "oxfmt --check",
-        "lint": "pnpm run eslint",
+        "lint": "pnpm run oxlint && pnpm run eslint",
         "lint-fix": "pnpm run eslint -- --fix",
         "oxlint": "oxlint --type-aware",
         "eslint": "eslint .",


### PR DESCRIPTION
- it turns out that sometimes in a local dev environment it is easy to forget to run both of them, so makes sense to combine