### PR TITLE
chore: remove unnecessary ignore directives in oxfmt & oxlint

### DIFF
--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     endOfLine: 'lf',
     insertFinalNewline: true,
     proseWrap: 'preserve',
-    ignorePatterns: ['node_modules/**', '.git/**', 'pnpm-lock.yaml'],
+    ignorePatterns: ['pnpm-lock.yaml'],
     sortImports: true,
     overrides: [
         {

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -44,5 +44,4 @@ export default defineConfig({
         'no-useless-escape': 'warn',
         'no-var': 'warn',
     },
-    ignorePatterns: ['node_modules/**', '.git/**'],
 });


### PR DESCRIPTION
- `.git` is ignored by default, and `node_modules` is part of `.gitignore` which oxc respects;
- idea from https://github.com/murdos/musicbrainz-userscripts/pull/942#discussion_r3448962554.