### PR TITLE
feat(elasticstage_importer): init; introduce the importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [Import CD1D releases to MusicBrainz](#cd1d_importer)
 - [Import Deezer releases into MusicBrainz](#deezer_importer)
 - [Import Discogs releases to MusicBrainz](#discogs_importer)
+- [<img src="assets/icons/typescript.svg" alt="TypeScript" width="16" height="16"> Import ElasticStage releases to MusicBrainz](#elasticstage_importer)
 - [Import Encyclopedisque releases to MusicBrainz](#encyclopedisque_importer)
 - [Import FMA releases to MusicBrainz](#fma_importer)
 - [Import HDtracks releases into MusicBrainz](#hdtracks_importer)
@@ -76,6 +77,13 @@ Add a button to import Discogs releases to MusicBrainz and add links to matching
 
 [![Source](assets/buttons/button-source.svg)](https://github.com/murdos/musicbrainz-userscripts/blob/master/discogs_importer.user.js)
 [![Install](assets/buttons/button-install.svg)](https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/discogs_importer.user.js)
+
+## <a name="elasticstage_importer"></a> <img src="assets/icons/typescript.svg" alt="TypeScript" width="16" height="16"> Import ElasticStage releases to MusicBrainz
+
+One-click importing of releases from elasticstage.com release pages into MusicBrainz
+
+[![Source](assets/buttons/button-source.svg)](https://github.com/murdos/musicbrainz-userscripts/blob/dist/elasticstage_importer.user.js)
+[![Install](assets/buttons/button-install.svg)](https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/elasticstage_importer.user.js)
 
 ## <a name="encyclopedisque_importer"></a> Import Encyclopedisque releases to MusicBrainz
 

--- a/src/types/importers.ts
+++ b/src/types/importers.ts
@@ -17,7 +17,7 @@ export interface URL {
 }
 
 export interface Track {
-    number?: number;
+    number?: number | string;
     title: string;
     duration?: number | string;
     artist_credit: ArtistCredit[];

--- a/src/userscripts/elasticstage_importer/index.ts
+++ b/src/userscripts/elasticstage_importer/index.ts
@@ -1,0 +1,384 @@
+import { Logger, LogLevel } from '~/lib/logger';
+import { MBImport } from '~/lib/mbimport';
+import { MBImportStyle } from '~/lib/mbimportstyle';
+import { subscribeToSPANavigation } from '~/lib/shared/spa-navigation';
+import { type ArtistCredit, type Disc, type Label, type Release, type Track, type URL } from '~/types/importers';
+
+import type { ElasticStageRelease } from './types';
+import { waitForReleases } from './utils/getElasticStageData';
+
+const LOGGER = new Logger('elasticstage_importer', LogLevel.INFO);
+
+const MB_IMPORT_CONTAINER_ID = 'mb_elasticstage_import';
+const MB_STYLE_ID = 'mb_elasticstage_style';
+const MB_MINIMIZED_CLASS = 'mb-es-minimized';
+const MB_MINIMIZED_STORAGE_KEY = 'mb_elasticstage_minimized';
+const MB_LOGO_URL =
+    'https://raw.githubusercontent.com/metabrainz/design-system/master/brand/logos/MusicBrainz/SVG/MusicBrainz_logo_icon.svg';
+
+function isMinimizedPreferred(): boolean {
+    try {
+        return window.localStorage.getItem(MB_MINIMIZED_STORAGE_KEY) === '1';
+    } catch {
+        return false;
+    }
+}
+
+function saveMinimizedPreference(minimized: boolean): void {
+    try {
+        window.localStorage.setItem(MB_MINIMIZED_STORAGE_KEY, minimized ? '1' : '0');
+    } catch {
+        // localStorage unavailable; preference simply won't persist
+    }
+}
+
+/** Detect a release page, e.g. /{artist}/releases/{release}. */
+function isReleasePage(): boolean {
+    return /^\/[^/]+\/releases\/[^/]+/.test(window.location.pathname);
+}
+
+/** Remove any previously inserted import UI to avoid duplicates on SPA navigation. */
+function cleanup(): void {
+    document.getElementById(MB_IMPORT_CONTAINER_ID)?.remove();
+}
+
+/** Map an elasticstage medium string to a MusicBrainz medium format. */
+function mapMediumFormat(medium: string): string {
+    switch (medium.trim().toLowerCase()) {
+        case 'cd':
+            return 'CD';
+        case 'vinyl':
+            return 'Vinyl';
+        case 'cassette':
+            return 'Cassette';
+        default:
+            return medium;
+    }
+}
+
+/** Map an elasticstage format string to a MusicBrainz primary release type. */
+function mapPrimaryType(format: string): string {
+    switch (format.trim().toLowerCase()) {
+        case 'album':
+            return 'album';
+        case 'single':
+            return 'single';
+        case 'ep':
+            return 'EP';
+        default:
+            return '';
+    }
+}
+
+/** Normalise the elasticstage artist fields into a flat list of artist names. */
+function normalizeArtists(primary: string, additional: unknown[]): string[] {
+    const names: string[] = [];
+    if (primary) {
+        names.push(primary);
+    }
+    for (const entry of additional) {
+        if (typeof entry === 'string') {
+            if (entry) names.push(entry);
+        } else if (entry && typeof entry === 'object') {
+            const record = entry as Record<string, unknown>;
+            const name = record['name'] ?? record['primary_artist'] ?? record['artist'];
+            if (typeof name === 'string' && name) {
+                names.push(name);
+            }
+        }
+    }
+    return names;
+}
+
+function buildTrackTitle(title: string, subtitle: string | null): string {
+    const trimmedSubtitle = subtitle?.trim();
+    if (trimmedSubtitle) {
+        return `${title} (${trimmedSubtitle})`;
+    }
+    return title;
+}
+
+function buildReleaseInfo(release_url: string, esRelease: ElasticStageRelease): Release {
+    const releaseDate = esRelease.release_date.split('T')[0]?.split('-') ?? [];
+
+    const medium = esRelease.release_type.product_type.medium;
+    const mediumFormat = mapMediumFormat(medium);
+    const isVinyl = medium.trim().toLowerCase() === 'vinyl';
+
+    const mbrelease = {
+        artist_credit: [] as ArtistCredit[],
+        title: esRelease.title,
+        year: parseInt(releaseDate[0] || '0'),
+        month: parseInt(releaseDate[1] || '0'),
+        day: parseInt(releaseDate[2] || '0'),
+        format: mediumFormat,
+        country: 'XW',
+        status: 'official',
+        type: mapPrimaryType(esRelease.release_type.format || ''),
+        urls: [] as URL[],
+        labels: [] as Label[],
+        barcode: esRelease.ean,
+        discs: [] as Disc[],
+    } satisfies Release;
+
+    mbrelease.artist_credit = MBImport.makeArtistCredits(normalizeArtists(esRelease.primary_artist, esRelease.additional_artists));
+
+    mbrelease.urls.push({
+        url: release_url,
+        link_type: MBImport.URL_TYPES.purchase_for_mail_order,
+    });
+
+    if (esRelease.label) {
+        const label: Label = { name: esRelease.label };
+        // elasticstage often reuses the EAN as the catalog number; only keep a
+        // genuine catalog number to avoid polluting MB with the barcode.
+        if (esRelease.catalog_no && esRelease.catalog_no !== esRelease.ean) {
+            label.catno = esRelease.catalog_no;
+        }
+        mbrelease.labels.push(label);
+    }
+
+    const mbtracks: Track[] = [];
+    const sideCounters: Record<number, number> = {};
+    for (const sideGroup of esRelease.tracks) {
+        for (const esTrack of sideGroup) {
+            const artists = normalizeArtists(esTrack.primary_artist, esTrack.additional_artists);
+            const track: Track = {
+                artist_credit: MBImport.makeArtistCredits(artists),
+                title: buildTrackTitle(esTrack.title, esTrack.subtitle),
+                duration: Math.round(esTrack.duration * 1000),
+            };
+            if (isVinyl) {
+                const side = esTrack.side || 1;
+                sideCounters[side] = (sideCounters[side] ?? 0) + 1;
+                track.number = `${String.fromCharCode(64 + side)}${sideCounters[side]}`;
+            }
+            mbtracks.push(track);
+        }
+    }
+
+    mbrelease.discs.push({
+        tracks: mbtracks,
+        format: mediumFormat,
+    });
+
+    return mbrelease;
+}
+
+function buildStyles(): void {
+    if (document.getElementById(MB_STYLE_ID)) {
+        return;
+    }
+    const style = document.createElement('style');
+    style.id = MB_STYLE_ID;
+    style.textContent = `
+        #${MB_IMPORT_CONTAINER_ID} {
+            position: fixed;
+            left: 16px;
+            bottom: 16px;
+            z-index: 2147483646;
+            max-width: 360px;
+            max-height: 70vh;
+            overflow-y: auto;
+            background: rgba(255, 255, 255, 0.97);
+            color: #222;
+            border: 1px solid rgba(120, 120, 120, 0.6);
+            border-radius: 8px;
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+            padding: 10px 12px;
+            font-family: Arial, sans-serif;
+            font-size: 12px;
+        }
+        #${MB_IMPORT_CONTAINER_ID} .mb-es-header {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            font-weight: bold;
+            margin-bottom: 8px;
+        }
+        #${MB_IMPORT_CONTAINER_ID} .mb-es-logo {
+            flex: none;
+        }
+        #${MB_IMPORT_CONTAINER_ID} .mb-es-minimize {
+            margin-left: auto;
+            cursor: pointer;
+            border: none;
+            background: transparent;
+            color: #555;
+            font-size: 16px;
+            line-height: 1;
+            padding: 0 4px;
+        }
+        #${MB_IMPORT_CONTAINER_ID} .mb-es-minimize:hover {
+            color: #000;
+        }
+        #${MB_IMPORT_CONTAINER_ID}.mb-es-minimized {
+            max-width: none;
+            width: 44px;
+            height: 44px;
+            padding: 0;
+            overflow: hidden;
+            cursor: pointer;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        #${MB_IMPORT_CONTAINER_ID}.mb-es-minimized .mb-es-header {
+            margin-bottom: 0;
+        }
+        #${MB_IMPORT_CONTAINER_ID}.mb-es-minimized .mb-es-title,
+        #${MB_IMPORT_CONTAINER_ID}.mb-es-minimized .mb-es-minimize,
+        #${MB_IMPORT_CONTAINER_ID}.mb-es-minimized .mb-es-release {
+            display: none;
+        }
+        #${MB_IMPORT_CONTAINER_ID} .mb-es-release {
+            border-top: 1px solid rgba(120, 120, 120, 0.25);
+            padding-top: 8px;
+            margin-top: 8px;
+        }
+        #${MB_IMPORT_CONTAINER_ID} .mb-es-release:first-of-type {
+            border-top: none;
+            padding-top: 0;
+            margin-top: 0;
+        }
+        #${MB_IMPORT_CONTAINER_ID} .mb-es-release-title {
+            font-weight: bold;
+            margin-bottom: 2px;
+        }
+        #${MB_IMPORT_CONTAINER_ID} .mb-es-release-meta {
+            color: #555;
+            margin-bottom: 6px;
+        }
+        #${MB_IMPORT_CONTAINER_ID} .mb-es-buttons {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+            align-items: center;
+        }
+    `;
+    document.head.appendChild(style);
+}
+
+function buildReleaseBlock(esRelease: ElasticStageRelease, mbrelease: Release, release_url: string): HTMLElement {
+    const block = document.createElement('div');
+    block.className = 'mb-es-release';
+
+    const title = document.createElement('div');
+    title.className = 'mb-es-release-title';
+    title.textContent = esRelease.release_type.description || esRelease.release_type.product_type.medium;
+    block.appendChild(title);
+
+    const metaLine = document.createElement('div');
+    metaLine.className = 'mb-es-release-meta';
+    const metaParts = [`${mbrelease.discs[0]?.tracks.length ?? 0} tracks`];
+    if (esRelease.ean) metaParts.push(`Barcode: ${esRelease.ean}`);
+    if (esRelease.is_limited_edition) metaParts.push('Limited edition');
+    metaLine.textContent = metaParts.join(' · ');
+    block.appendChild(metaLine);
+
+    const editNote = MBImport.makeEditNote(release_url, 'ElasticStage', esRelease.release_type.description);
+    const parameters = MBImport.buildFormParameters(mbrelease, editNote);
+
+    const buttons = document.createElement('div');
+    buttons.className = 'mb-es-buttons';
+    buttons.innerHTML = MBImport.buildFormHTML(parameters) + MBImport.buildSearchButton(mbrelease);
+    block.appendChild(buttons);
+
+    return block;
+}
+
+function insertMBButtons(esReleases: ElasticStageRelease[], release_url: string): void {
+    if (esReleases.length === 0) {
+        LOGGER.error('No releases found to import');
+        return;
+    }
+
+    buildStyles();
+
+    const container = document.createElement('div');
+    container.id = MB_IMPORT_CONTAINER_ID;
+
+    const header = document.createElement('div');
+    header.className = 'mb-es-header';
+    header.innerHTML = `
+        <img class="mb-es-logo" src="${MB_LOGO_URL}" width="18" height="18" />
+        <span class="mb-es-title">Import to MusicBrainz</span>
+        <button type="button" class="mb-es-minimize" title="Minimise" aria-label="Minimise">&minus;</button>
+    `;
+    container.appendChild(header);
+
+    const setMinimized = (minimized: boolean): void => {
+        container.classList.toggle(MB_MINIMIZED_CLASS, minimized);
+        container.title = minimized ? 'Expand MusicBrainz import' : '';
+        saveMinimizedPreference(minimized);
+    };
+
+    header.querySelector('.mb-es-minimize')?.addEventListener('click', event => {
+        event.stopPropagation();
+        setMinimized(true);
+    });
+
+    // When collapsed to an icon, a click anywhere on it expands it again.
+    container.addEventListener('click', () => {
+        if (container.classList.contains(MB_MINIMIZED_CLASS)) {
+            setMinimized(false);
+        }
+    });
+
+    for (const esRelease of esReleases) {
+        const mbrelease = buildReleaseInfo(release_url, esRelease);
+        container.appendChild(buildReleaseBlock(esRelease, mbrelease, release_url));
+    }
+
+    if (isMinimizedPreferred()) {
+        container.classList.add(MB_MINIMIZED_CLASS);
+        container.title = 'Expand MusicBrainz import';
+    }
+
+    document.body.appendChild(container);
+}
+
+async function processReleasePage(): Promise<void> {
+    cleanup();
+
+    if (!isReleasePage()) {
+        return;
+    }
+
+    try {
+        const releases = await waitForReleases();
+
+        // The page may have re-rendered while we waited; bail out if we navigated away.
+        if (!isReleasePage()) {
+            return;
+        }
+
+        if (releases.length === 0) {
+            LOGGER.error('Could not find release data in the page state');
+            return;
+        }
+
+        const release_url = window.location.href.replace(/[?#].*$/, '');
+        insertMBButtons(releases, release_url);
+    } catch (error) {
+        LOGGER.error('Error processing release page:', error);
+    }
+}
+
+function init(): void {
+    MBImportStyle();
+    setTimeout(() => {
+        void processReleasePage();
+    }, 1000);
+}
+
+subscribeToSPANavigation({
+    onNavigate: () => processReleasePage(),
+});
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+} else {
+    init();
+}

--- a/src/userscripts/elasticstage_importer/meta.json
+++ b/src/userscripts/elasticstage_importer/meta.json
@@ -1,0 +1,13 @@
+{
+    "name": "Import ElasticStage releases to MusicBrainz",
+    "description": "One-click importing of releases from elasticstage.com release pages into MusicBrainz",
+    "version": "2026.06.28.1",
+    "author": "Raman Sinclair",
+    "namespace": "https://github.com/murdos/musicbrainz-userscripts/",
+    "downloadURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/elasticstage_importer.user.js",
+    "updateURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/elasticstage_importer.user.js",
+    "match": ["https://elasticstage.com/*"],
+    "grant": ["none"],
+    "runAt": "document-start",
+    "icon": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png"
+}

--- a/src/userscripts/elasticstage_importer/types.ts
+++ b/src/userscripts/elasticstage_importer/types.ts
@@ -1,0 +1,59 @@
+/**
+ * Types describing the subset of the elasticstage.com release data that the
+ * importer relies on. The data is read out of the page's Vue component state;
+ * only fields actually consumed by the script are typed, the state holds many
+ * more.
+ */
+
+/** A single track within a release. */
+export type ElasticStageTrack = {
+    uuid: string;
+    title: string;
+    subtitle: string | null;
+    /** 1-based physical side index (relevant for vinyl). */
+    side: number;
+    /** Duration in seconds (may be fractional). */
+    duration: number;
+    explicit: boolean;
+    primary_artist: string;
+    additional_artists: unknown[];
+};
+
+/** The product (medium) type backing a physical release. */
+export type ElasticStageProductType = {
+    /** e.g. "CD", "Vinyl". */
+    medium: string;
+    description: string;
+    /** Number of physical sides (1 for CD, 2 for a single vinyl LP, ...). */
+    sides: number;
+};
+
+/** Description of the release format, e.g. "CD | Album". */
+export type ElasticStageReleaseType = {
+    description: string;
+    product_type: ElasticStageProductType;
+    /** Primary type, e.g. "Album", "Single", "EP". */
+    format: string;
+};
+
+/** A single purchasable physical release (one per format). */
+export type ElasticStageRelease = {
+    uuid: string;
+    /** ISO 8601 date string. */
+    release_date: string;
+    year: string;
+    ean: string;
+    title: string;
+    catalog_no: string;
+    primary_artist: string;
+    additional_artists: unknown[];
+    explicit: boolean;
+    label: string;
+    track_count: number;
+    /** Total playtime in seconds. */
+    total_playtime: number;
+    release_type: ElasticStageReleaseType;
+    /** Tracks grouped by physical side. */
+    tracks: ElasticStageTrack[][];
+    is_limited_edition: boolean;
+};

--- a/src/userscripts/elasticstage_importer/utils/getElasticStageData.ts
+++ b/src/userscripts/elasticstage_importer/utils/getElasticStageData.ts
@@ -1,0 +1,98 @@
+import type { ElasticStageRelease } from '../types';
+
+/**
+ * elasticstage.com is a Vue 3 single-page app. The release page fetches the
+ * release group's releases itself and keeps them in the Vue component state, so
+ * instead of issuing our own API requests we read the data straight out of the
+ * mounted components. This requires running in page context (`@grant none`) so
+ * that the `__vueParentComponent` expando property added by Vue is visible.
+ */
+
+/** Minimal shape of a mounted Vue 3 internal component instance. */
+type VueComponentInstance = {
+    type?: { name?: string; __name?: string };
+    props?: Record<string, unknown> | null;
+};
+
+type VueElement = Element & { __vueParentComponent?: VueComponentInstance };
+
+/** The component that renders the list of purchasable formats for a release group. */
+const RELEASE_DETAILS_COMPONENT = 'ReleaseDetails';
+
+/** Does this value look like the array of releases exposed by the page? */
+function isReleaseArray(value: unknown): value is ElasticStageRelease[] {
+    if (!Array.isArray(value) || value.length === 0) {
+        return false;
+    }
+    const [first] = value as unknown[];
+    return typeof first === 'object' && first !== null && 'ean' in first && 'tracks' in first && 'release_type' in first;
+}
+
+/**
+ * Walk the mounted Vue components and return the release list held in state.
+ * Prefers the dedicated `ReleaseDetails` component but falls back to any
+ * component prop that looks like the release array, in case elasticstage
+ * renames or restructures its components.
+ */
+export function getReleasesFromVueState(): ElasticStageRelease[] {
+    let fallback: ElasticStageRelease[] | null = null;
+
+    for (const el of document.querySelectorAll<VueElement>('*')) {
+        const component = el.__vueParentComponent;
+        const props = component?.props;
+        if (!props) {
+            continue;
+        }
+
+        const name = component.type?.name ?? component.type?.__name;
+        if (name === RELEASE_DETAILS_COMPONENT && isReleaseArray(props['releases'])) {
+            return cloneReleases(props['releases']);
+        }
+
+        if (!fallback) {
+            for (const key of Object.keys(props)) {
+                let value: unknown;
+                try {
+                    value = props[key];
+                } catch {
+                    continue;
+                }
+                if (isReleaseArray(value)) {
+                    fallback = value;
+                    break;
+                }
+            }
+        }
+    }
+
+    return fallback ? cloneReleases(fallback) : [];
+}
+
+/**
+ * Detach the data from Vue's reactive proxies, returning plain serialisable
+ * objects. The release data is plain JSON, so a structured clone is sufficient.
+ */
+function cloneReleases(releases: ElasticStageRelease[]): ElasticStageRelease[] {
+    try {
+        return JSON.parse(JSON.stringify(releases)) as ElasticStageRelease[];
+    } catch {
+        return releases;
+    }
+}
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Poll for the release data, which is populated asynchronously after the page
+ * (or an SPA navigation) finishes fetching it.
+ */
+export async function waitForReleases(maxAttempts = 40, intervalMs = 250): Promise<ElasticStageRelease[]> {
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        const releases = getReleasesFromVueState();
+        if (releases.length > 0) {
+            return releases;
+        }
+        await sleep(intervalMs);
+    }
+    return [];
+}


### PR DESCRIPTION
Adds a new userscript, **Import ElasticStage releases to MusicBrainz**, that puts one-click import buttons on [elasticstage.com](https://elasticstage.com) release pages.

### What it does

ElasticStage is a print-on-demand vinyl/CD service. Each release page (`/{artist}/releases/{release}`) can offer the same album in several physical formats (e.g. Vinyl + CD). This script detects those release pages and renders a small floating MusicBrainz panel with a separate **import** + **search** button for every physical format, pre-filling the MB "Add Release" form with the title, artist credits, tracklist, label, barcode, date and format.

Test URL: [elasticstage.com/yunomilesvinyl/releases/yuno-greatest-hits-album](https://elasticstage.com/yunomilesvinyl/releases/yuno-greatest-hits-album)

Screenshots:

| LP + CD, Full | 1 Medium | Minimised |
|--------|--------|--------|
| <img width="381" height="377" alt="image" src="https://github.com/user-attachments/assets/78ac84de-f99a-4745-91c2-3b32fa5f8325" /> | <img width="402" height="377" alt="image" src="https://github.com/user-attachments/assets/4eef4a64-633f-4cdd-b135-900be349b763" /> | <img width="381" height="377" alt="image" src="https://github.com/user-attachments/assets/b558a998-36eb-453c-bd37-f181e558a25a" /> | 

### How it works

ElasticStage is a Vue 3 single-page app that fetches a release group's data itself and keeps it in component state. Rather than issuing duplicate API requests, the script reads the data **directly out of the mounted Vue components**:

- It walks the DOM for elements carrying Vue's `__vueParentComponent`, finds the `ReleaseDetails` component, and pulls its `releases` prop — the full array of physical releases with tracks, formats, label, barcode, etc. (with a structural fallback in case ElasticStage renames the component).
- The data is deep-cloned off Vue's reactive proxies into plain objects before use.
- Because the data loads asynchronously, the script polls the component state until the releases appear (then bails gracefully if the user has navigated away).

Each release is then converted into a MusicBrainz release object and rendered using the shared `MBImport` helpers (`buildFormParameters` / `buildFormHTML` / `buildSearchButton`).

### Script metadata

- `@match https://elasticstage.com/*`
- `@grant none` (runs in page context so Vue internals are visible)
- `@run-at document-start`

---

Description written with an LLM based on the script's functionality.