### PR TITLE
feat(mb_ui_enhancements): add relationship editor shortcut buttons

### DIFF
--- a/mb_ui_enhancements.user.js
+++ b/mb_ui_enhancements.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Musicbrainz UI enhancements
 // @description  Various UI enhancements for Musicbrainz
-// @version      2026.2.12.4
+// @version      2026.7.5.4
 // @downloadURL  https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/mb_ui_enhancements.user.js
 // @updateURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/mb_ui_enhancements.user.js
 // @icon         http://wiki.musicbrainz.org/-/images/3/3d/Musicbrainz_logo.png
@@ -20,10 +20,120 @@
 // @grant        GM_registerMenuCommand
 // @grant        GM_getValue
 // @grant        GM_setValue
+// @grant        GM_addElement
 // ==/UserScript==
 
 // prevent JQuery conflicts, see http://wiki.greasespot.net/@grant
 this.$ = this.jQuery = jQuery.noConflict(true);
+
+// Runs in page context (via GM_addElement) where globalThis.MB is defined.
+const REL_EDITOR_PAGE_LISTENER = `(function () {
+    if (window.__mbUiRelEditorShortcutsInstalled) return;
+    window.__mbUiRelEditorShortcutsInstalled = true;
+
+    function createBatchSourcePlaceholder(entityType) {
+        if (entityType === 'recording') {
+            return {
+                entityType: 'recording',
+                name: '',
+                id: 0,
+                gid: '',
+                comment: '',
+                editsPending: false,
+                last_updated: null,
+                artistCredit: { names: [] },
+                isrcs: [],
+                length: 0,
+                related_works: [],
+                video: false,
+            };
+        }
+        return {
+            entityType: 'work',
+            name: '',
+            id: 0,
+            gid: '',
+            comment: '',
+            editsPending: false,
+            last_updated: null,
+            artists: [],
+            attributes: [],
+            authors: [],
+            iswcs: [],
+            languages: [],
+            typeID: null,
+        };
+    }
+
+    function resolveSourceEntity(re, sourceType) {
+        if (sourceType === 'release_group') {
+            return re.state.entity.releaseGroup;
+        }
+        if (sourceType === 'release') {
+            return re.state.entity;
+        }
+        if (sourceType === 'recording' || sourceType === 'work') {
+            return createBatchSourcePlaceholder(sourceType);
+        }
+        return null;
+    }
+
+    document.addEventListener('click', function (event) {
+        var button = event.target.closest('.mb-ui-rel-shortcut-btn');
+        if (!button || button.disabled) return;
+
+        event.preventDefault();
+
+        var MB = globalThis.MB;
+        var re = MB && MB.relationshipEditor;
+        if (!re || !re.dispatch) return;
+
+        var sourceType = button.getAttribute('data-source-type');
+        var targetType = button.getAttribute('data-target-type');
+        var source = resolveSourceEntity(re, sourceType);
+        if (!source) return;
+
+        var isBatch = sourceType === 'recording' || sourceType === 'work';
+        re.dispatch({
+            type: 'update-dialog-location',
+            location: isBatch
+                ? { batchSelection: true, source: source, track: null }
+                : { source: source, track: null },
+        });
+
+        if (!targetType) return;
+
+        var waitForDialog = function () {
+            if (re.relationshipDialogDispatch) {
+                re.relationshipDialogDispatch({
+                    type: 'update-target-type',
+                    source: source,
+                    targetType: targetType,
+                });
+            } else {
+                requestAnimationFrame(waitForDialog);
+            }
+        };
+        requestAnimationFrame(waitForDialog);
+    }, true);
+})();`;
+
+let relEditorPageBridgeInstalled = false;
+
+function installRelEditorPageBridge() {
+    if (relEditorPageBridgeInstalled) return;
+    relEditorPageBridgeInstalled = true;
+
+    if (typeof GM_addElement === 'function') {
+        GM_addElement('script', { textContent: REL_EDITOR_PAGE_LISTENER });
+        return;
+    }
+
+    const script = document.createElement('script');
+    script.textContent = REL_EDITOR_PAGE_LISTENER;
+    (document.head || document.documentElement).appendChild(script);
+    script.remove();
+}
 
 // Copy release title: menu command to enable/disable (default enabled)
 function setCopyTitleMenu() {
@@ -53,6 +163,20 @@ function setGoogleSearchMenu() {
 }
 setGoogleSearchMenu();
 
+// Relationship editor shortcut buttons: menu command to enable/disable (default enabled)
+function setRelEditorShortcutsMenu() {
+    if (typeof GM_registerMenuCommand !== 'function') return;
+    GM_registerMenuCommand(
+        `${GM_getValue('relEditorShortcutsEnabled', true) ? '☑' : '☐'} Relationship editor shortcut buttons`,
+        function () {
+            GM_setValue('relEditorShortcutsEnabled', !GM_getValue('relEditorShortcutsEnabled', true));
+            setRelEditorShortcutsMenu();
+        },
+        { autoClose: false, id: 'relEditorShortcuts' },
+    );
+}
+setRelEditorShortcutsMenu();
+
 $(document).ready(function () {
     // Follow the instructions found at https://www.last.fm/api/authentication
     // then paste your API Key between the single quotes in the variable below.
@@ -68,13 +192,12 @@ $(document).ready(function () {
         '<style>.release-title-action-btn { opacity: 0.8; transition: transform 0.15s ease, opacity 0.15s ease; } .release-title-action-btn:hover { opacity: 1; transform: scale(1.15); } .release-title-action-btn:active { transform: scale(1.05); }</style>',
     );
 
-    let re;
+    const artistRegex = new RegExp('musicbrainz.org/artist/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$', 'i');
 
     // Top tracks from Last.fm
-    re = new RegExp('musicbrainz.org/artist/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$', 'i');
-    if (LASTFM_APIKEY && window.location.href.match(re)) {
+    if (LASTFM_APIKEY && window.location.href.match(artistRegex)) {
         $('h2.discography').before('<h2 class="toptracks">Top Last.fm recordings</h2><ul class="toptracks" />');
-        const mbid = window.location.href.match(re)[1];
+        const mbid = window.location.href.match(artistRegex)[1];
         $.getJSON(
             `https://ws.audioscrobbler.com/2.0/?method=artist.gettoptracks&mbid=${mbid}&api_key=${LASTFM_APIKEY}&format=json`,
             function (data) {
@@ -88,8 +211,8 @@ $(document).ready(function () {
     }
 
     // Fix for http://tickets.musicbrainz.org/browse/MBS-750
-    re = new RegExp('musicbrainz.org/release/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})', 'i');
-    if (window.location.href.match(re)) {
+    const releaseRegex = new RegExp('musicbrainz.org/release/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})', 'i');
+    if (window.location.href.match(releaseRegex)) {
         if ($('table.medium thead').length == 1) {
             let text = $.trim($('table.medium thead').text());
             if (text.match(/ 1$/)) {
@@ -99,11 +222,11 @@ $(document).ready(function () {
     }
 
     // Better fix for http://tickets.musicbrainz.org/browse/MBS-1943
-    re = new RegExp(
+    const entityRegex = new RegExp(
         'musicbrainz.org/(artist|release-group|release|recording|work|label)/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})',
         'i',
     );
-    if (window.location.href.match(re)) {
+    if (window.location.href.match(entityRegex)) {
         $("#sidebar h2:contains('Rating')").before($("#sidebar h2:contains('External links')"));
         let pageHasRGLinks = $("#sidebar h2:contains('Release group external links')").length > 0;
         $("#sidebar h2:contains('Rating')").before(
@@ -118,20 +241,20 @@ $(document).ready(function () {
     }
 
     // Remove the affiliate section
-    re = new RegExp(
+    const affiliateRegex = new RegExp(
         'musicbrainz.org/(artist|release-group|release|recording|work|label)/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})',
         'i',
     );
-    if (window.location.href.match(re)) {
+    if (window.location.href.match(affiliateRegex)) {
         $('#sidebar-affiliates').remove();
     }
 
     // Batch merge -> open in a new tab/windows
-    re = new RegExp(
+    const batchMergeRegex = new RegExp(
         'musicbrainz.org/artist/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/(recordings|releases|works)',
         'i',
     );
-    if (window.location.href.match(re)) {
+    if (window.location.href.match(batchMergeRegex)) {
         $('form')
             .filter(function () {
                 return $(this).prop('action').match('merge_queue');
@@ -140,8 +263,8 @@ $(document).ready(function () {
     }
 
     // Modify link to edits: remove " - <Edit type>" from the link "Edit XXXX - <Edit type>"
-    re = new RegExp('musicbrainz.org/.*/(open_)?edits', 'i');
-    if (window.location.href.match(re)) {
+    const editsRegex = new RegExp('musicbrainz.org/.*/(open_)?edits', 'i');
+    if (window.location.href.match(editsRegex)) {
         $('div.edit-description ~ h2').each(function () {
             let parts = $(this).find('a').text().split(' - ');
             $(this).find('a').text(parts[0]);
@@ -150,8 +273,8 @@ $(document).ready(function () {
     }
 
     // Add direct link to cover art tab for Add cover art edits
-    re = new RegExp('musicbrainz.org/(.*/(open_)?edits|edit/d+)', 'i');
-    if (window.location.href.match(re)) {
+    const coverArtRegex = new RegExp('musicbrainz.org/(.*/(open_)?edits|edit/d+)', 'i');
+    if (window.location.href.match(coverArtRegex)) {
         $("div.edit-description ~ h2:contains('cover art')").each(function () {
             const $editdetails = $(this).parents('.edit-header').siblings('.edit-details');
             const mbid = $editdetails
@@ -165,8 +288,8 @@ $(document).ready(function () {
     }
 
     // Embed Youtube videos
-    re = new RegExp('musicbrainz.org/recording/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$', 'i');
-    if (window.location.href.match(re)) {
+    const recordingRegex = new RegExp('musicbrainz.org/recording/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$', 'i');
+    if (window.location.href.match(recordingRegex)) {
         let $youtube_link = $('#sidebar li.youtube-favicon a');
         if ($youtube_link.length > 0) {
             let youtube_id = $youtube_link.prop('href').match(/http:\/\/www\.youtube\.com\/watch\?v=(.*)/)[1];
@@ -178,8 +301,8 @@ $(document).ready(function () {
     }
 
     // When attaching CDTOC, autoselect artist when there's only one result
-    re = new RegExp('musicbrainz.org/cdtoc/attach.*&filter-artist.query=.*', 'i');
-    if (window.location.href.match(re)) {
+    const cdtocRegex = new RegExp('musicbrainz.org/cdtoc/attach.*&filter-artist.query=.*', 'i');
+    if (window.location.href.match(cdtocRegex)) {
         const $artists = $('ul.radio-list li');
         if ($artists.length == 1) {
             $artists.find('input:radio').attr('checked', true);
@@ -187,8 +310,11 @@ $(document).ready(function () {
     }
 
     // Highlight Year in ISRCs codes
-    re = new RegExp('musicbrainz.org/artist/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/recordings', 'i');
-    if (window.location.href.match(re)) {
+    const artistRecordingsRegex = new RegExp(
+        'musicbrainz.org/artist/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/recordings',
+        'i',
+    );
+    if (window.location.href.match(artistRecordingsRegex)) {
         let isrcColNo; // = ($("#content table.tbl thead th:eq(2)").text() == "Artist") ? 3 : 2;
         $('#content table.tbl thead th').each(function (index, th) {
             if ($(th).text() == 'ISRCs') {
@@ -212,9 +338,12 @@ $(document).ready(function () {
     }
 
     // Release header buttons (search, copy) - on all release pages including sub-pages (cover-art, aliases, tags, etc.)
-    re = new RegExp('musicbrainz.org/release/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})(?:/[^?#]*)?(?:#.*)?$', 'i');
-    if (window.location.href.match(re)) {
-        const mbid = window.location.href.match(re)[1];
+    const releaseHeaderRegex = new RegExp(
+        'musicbrainz.org/release/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})(?:/[^?#]*)?(?:#.*)?$',
+        'i',
+    );
+    if (window.location.href.match(releaseHeaderRegex)) {
+        const mbid = window.location.href.match(releaseHeaderRegex)[1];
         const $releaseHeader = $('div.wrap-anywhere.releaseheader, div.releaseheader').first();
         const $h1 = $releaseHeader.children('h1');
         const releaseTitle = $h1.length ? $h1.text().replace(/\s+/g, ' ').trim() : '';
@@ -418,8 +547,7 @@ $(document).ready(function () {
     }
 
     // Display a-tisket links next to Deezer, Spotify, iTunes and Apple Music links
-    re = new RegExp('musicbrainz.org/release/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})', 'i');
-    if (window.location.href.match(re)) {
+    if (window.location.href.match(releaseRegex)) {
         document.querySelectorAll('div#bottom-credits a').forEach(function (link) {
             if (link.href.match(/deezer.com|(music|itunes).apple.com|spotify.com/)) {
                 let id;
@@ -453,6 +581,192 @@ $(document).ready(function () {
 
     // Discogs link rollover
     // TODO...
+
+    // Add-relationship shortcuts on the release relationship editor
+    const relationshipEditorRegex = new RegExp(
+        'musicbrainz.org/release/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/edit-relationships',
+        'i',
+    );
+    if (window.location.href.match(relationshipEditorRegex) && GM_getValue('relEditorShortcutsEnabled', true)) {
+        const RELEASE_REL_TARGET_TYPES = ['area', 'artist', 'event', 'label', 'place', 'recording', 'release', 'series'];
+        const RELEASE_GROUP_REL_TARGET_TYPES = ['artist', 'event', 'genre', 'label', 'release_group', 'series', 'work'];
+        const RECORDING_REL_TARGET_TYPES = ['area', 'artist', 'event', 'label', 'place', 'recording', 'release', 'series', 'work'];
+        const WORK_REL_TARGET_TYPES = ['area', 'artist', 'event', 'label', 'place', 'recording', 'release_group', 'series', 'work'];
+        const REL_EDITOR_SECTIONS = [
+            { containerId: 'release-rels', sourceType: 'release', targetTypes: RELEASE_REL_TARGET_TYPES },
+            { containerId: 'release-group-rels', sourceType: 'release_group', targetTypes: RELEASE_GROUP_REL_TARGET_TYPES },
+        ];
+        const BATCH_REL_SECTIONS = [
+            {
+                batchButtonSelector: '.batch-add-recording-relationship',
+                sourceType: 'recording',
+                targetTypes: RECORDING_REL_TARGET_TYPES,
+            },
+            {
+                batchButtonSelector: '.batch-add-work-relationship',
+                sourceType: 'work',
+                targetTypes: WORK_REL_TARGET_TYPES,
+            },
+        ];
+
+        $('head').append(`<style>
+h2.mb-ui-rel-header {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+h2.mb-ui-rel-header .mb-ui-rel-shortcuts {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 2px;
+    margin-left: 4px;
+    font-weight: normal;
+    line-height: 1;
+}
+.mb-ui-rel-shortcuts {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 2px;
+    margin-top: 4px;
+}
+.mb-ui-rel-shortcut-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    padding: 1px 4px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    background: #f8f8f8;
+    cursor: pointer;
+    line-height: 1.2;
+    font-size: 11px;
+    vertical-align: middle;
+}
+.mb-ui-rel-shortcut-btn:hover:not(:disabled) {
+    background: #ffeea8;
+    border-color: #999;
+}
+.mb-ui-rel-shortcut-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    background: #eee;
+}
+.mb-ui-rel-shortcut-btn img {
+    width: 14px;
+    height: 14px;
+    display: block;
+    flex-shrink: 0;
+}
+.mb-ui-rel-shortcut-label {
+    line-height: 1;
+}
+</style>`);
+
+        const entityTypeLabel = function (entityType) {
+            return entityType.replace(/_/g, ' ').replace(/\b\w/g, function (c) {
+                return c.toUpperCase();
+            });
+        };
+
+        const createShortcutButtons = function ($container, sourceType, targetTypes, options) {
+            options = options || {};
+            if ($container.attr('data-mb-ui-rel-shortcuts') === 'yes') {
+                return $container.find('.mb-ui-rel-shortcuts');
+            }
+            if (options.headerLayout) {
+                $container.addClass('mb-ui-rel-header');
+            }
+            $container.attr('data-mb-ui-rel-shortcuts', 'yes');
+
+            const $shortcuts = $('<span class="mb-ui-rel-shortcuts" />');
+            const entityIconBase = `${window.location.origin}/static/images/entity`;
+
+            targetTypes.forEach(function (targetType) {
+                const $button = $('<button type="button" class="mb-ui-rel-shortcut-btn" />').attr({
+                    title: `Add ${entityTypeLabel(targetType)} relationship`,
+                    'data-source-type': sourceType,
+                    'data-target-type': targetType,
+                });
+                $button.append(
+                    $('<img />').attr({
+                        src: `${entityIconBase}/${targetType}.svg`,
+                        alt: '',
+                    }),
+                    $('<span class="mb-ui-rel-shortcut-label" />').text(entityTypeLabel(targetType)),
+                );
+                $shortcuts.append($button);
+            });
+
+            $container.append($shortcuts);
+            return $shortcuts;
+        };
+
+        const syncBatchShortcutDisabled = function (batchButtonSelector, $shortcuts) {
+            const batchBtn = document.querySelector(batchButtonSelector);
+            if (!batchBtn || !$shortcuts.length) return;
+
+            const sync = function () {
+                $shortcuts.find('.mb-ui-rel-shortcut-btn').prop('disabled', batchBtn.disabled);
+            };
+            sync();
+
+            const observer = new MutationObserver(sync);
+            observer.observe(batchBtn, { attributes: true, attributeFilter: ['disabled'] });
+        };
+
+        const initBatchRelShortcuts = function () {
+            const $batchTools = $('#batch-tools');
+            if (!$batchTools.length) return false;
+            if ($batchTools.attr('data-mb-ui-rel-shortcuts') === 'yes') return true;
+
+            const $row = $('<tr class="mb-ui-rel-batch-shortcuts-row" />');
+            $row.append($('<td />'));
+            $row.append($('<td />'));
+            $row.append($('<td />'));
+            $batchTools.find('tbody').append($row);
+
+            BATCH_REL_SECTIONS.forEach(function (section, index) {
+                const $shortcuts = createShortcutButtons(
+                    $row.children('td').eq(index === 0 ? 0 : 2),
+                    section.sourceType,
+                    section.targetTypes,
+                );
+                syncBatchShortcutDisabled(section.batchButtonSelector, $shortcuts);
+            });
+
+            $batchTools.attr('data-mb-ui-rel-shortcuts', 'yes');
+            return true;
+        };
+
+        const initRelEditorShortcuts = function () {
+            installRelEditorPageBridge();
+            let allReady = true;
+            REL_EDITOR_SECTIONS.forEach(function (section) {
+                const $header = $(`#${section.containerId}`).prev('h2');
+                if (!$header.length) {
+                    allReady = false;
+                    return;
+                }
+                createShortcutButtons($header, section.sourceType, section.targetTypes, { headerLayout: true });
+            });
+            if (!initBatchRelShortcuts()) {
+                allReady = false;
+            }
+            return allReady;
+        };
+
+        if (!initRelEditorShortcuts()) {
+            const relEditorObserver = new MutationObserver(function () {
+                if (initRelEditorShortcuts()) {
+                    relEditorObserver.disconnect();
+                }
+            });
+            relEditorObserver.observe(document.body, { childList: true, subtree: true });
+        }
+    }
 
     // -------------- End of script ------------------------
 });


### PR DESCRIPTION
- Adds shortcut buttons in Relationship Editor allowing to open the Add Relationship dialog with a particular entity already pre-selected. See screenshot below.
- I had to use a nasty approach of injecting the JS as a string via add element in order to bypass the isolation context between the script sandbox and the native browser window environment. Unfortunately, `function.toString()` approach didn't work for some reason. If in the future I find a better way of doing it, I will update the script.
- the feature can be disabled from the ViolentMonkey dropdown menu.

<img width="2003" height="1043" alt="image" src="https://github.com/user-attachments/assets/8027cdde-0266-4d53-a92e-803fd261e063" />
