### PR TITLE
fix(mb_discids_detector): prevent discid script from double-encoding the spaces

### DIFF
--- a/src/userscripts/mb_discids_detector/index.ts
+++ b/src/userscripts/mb_discids_detector/index.ts
@@ -11,14 +11,10 @@ const MB_BASE_URL = 'https://musicbrainz.org';
 const GAZELLE_HOST_PATTERN = /orpheus\.network|redacted\.sh|lztr\.me|notwhat\.cd/;
 
 function computeAttachUrl(mbTocNumbers: number[], mbArtistName: string, mbReleaseName: string): string {
-    const tocNumbers = mbTocNumbers.join('%20');
-    const artistName = encodeURIComponent(mbArtistName);
-    const releaseName = encodeURIComponent(mbReleaseName);
-
     const mbURL = new URL(`${MB_BASE_URL}/cdtoc/attach`);
-    mbURL.searchParams.set('toc', tocNumbers);
-    mbURL.searchParams.set('artist-name', artistName);
-    mbURL.searchParams.set('release-name', releaseName);
+    mbURL.searchParams.set('toc', mbTocNumbers.join(' '));
+    mbURL.searchParams.set('artist-name', mbArtistName);
+    mbURL.searchParams.set('release-name', mbReleaseName);
     return mbURL.toString();
 }
 


### PR DESCRIPTION
- this is a bug introduced by me during rewrite: URL.searchParams() already HTML-encodes the arguments so we don't have to pre-encode the space. Also, MB supports encoding spaces with `+` instead of `%20` which is way more readable.