### PR TITLE
chore(common): bump target browser environment to 2022 in all TS scripts

### DIFF
--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -17,7 +17,7 @@ const BABEL_OPTIONS = {
     include: ['**/*'],
     extensions: EXTENSIONS,
     targets: {
-        browsers: ['> 1%', 'last 2 versions', 'not ie <= 8'],
+        browsers: ['baseline 2022'],
     },
     presets: [
         [


### PR DESCRIPTION
- there's no real need to support anything below that, and bumping this to 2022 removes a massive amount of polyfills from built scripts as well as improves the performance;
- this is also to test the auto-increment script that I just deployed.