### PR TITLE
fix(bandcamp_importer): convert @include to @match to support MV3

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,15 +1,17 @@
 // ==UserScript==
 // @name         Import Bandcamp releases to MusicBrainz
 // @description  Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2026.06.21.1
+// @version      2026.7.7.1
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @include      /^https:\/\/[^/]+\/(?:(?:(?:album|track))\/[^/]+|music)$/
 // @include      /^https:\/\/([^.]+)\.bandcamp\.com((?:\/(?:(?:album|track))\/[^/]+|\/|\/music)?)$/
+// @match        https://*.bandcamp.com/*
 // @include      /^https:\/\/bandcamp\.com\/private\//
 // @include      /^https:\/\/([^.]+)\.bandcamp\.com\/private\//
 // @include      /^https?:\/\/web\.archive\.org\/web\/\d+\/https?:\/\/[^/]+(?:\/(?:album|track)\/[^/]+\/?|\/music\/?|\/?)$/
+// @match        https://web.archive.org/web/*
 // @require      lib/mbimport.js?version=v2026.05.30.1
 // @require      lib/logger.js
 // @require      lib/mblinks.js?version=v2026.05.31.1
@@ -398,7 +400,7 @@ const BandcampImport = {
     },
 };
 
-if (window.location.hostname === 'web.archive.org') {
+if (window.location.hostname === 'web.archive.org' && !!unsafeWindow.TralbumData) {
     const targetWindow = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;
     let _realWombat;
 


### PR DESCRIPTION
- part of #981;
- don't remove @include for now as it requires more testing;
- we will have to drop the possibility of running the script on whitelabelled bandcamp pages: MV3 doesn't support regex in the @match directives, so there's no way to narrow it down. If users complain that the script doesn't run on specific whitelabelled bandcamp pages, we can add those individual pages to the match list.
- webarchive matcher is also more broad now, which justifies an extra guard.