### PR TITLE
feat(ffm_importer): Add FFM release importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - [Import Discogs releases to MusicBrainz](#discogs_importer)
 - [<img src="assets/icons/typescript.svg" alt="TypeScript" width="16" height="16"> Import ElasticStage releases to MusicBrainz](#elasticstage_importer)
 - [Import Encyclopedisque releases to MusicBrainz](#encyclopedisque_importer)
+- [<img src="assets/icons/typescript.svg" alt="TypeScript" width="16" height="16"> Import FFM releases to MusicBrainz](#ffm_importer)
 - [Import FMA releases to MusicBrainz](#fma_importer)
 - [Import HDtracks releases into MusicBrainz](#hdtracks_importer)
 - [Import Loot releases to MusicBrainz](#loot_importer)
@@ -82,6 +83,13 @@ Easily import Encyclopedisque releases into MusicBrainz
 
 [![Source](assets/buttons/button-source.svg)](https://github.com/murdos/musicbrainz-userscripts/blob/master/encyclopedisque_importer.user.js)
 [![Install](assets/buttons/button-install.svg)](https://raw.github.com/murdos/musicbrainz-userscripts/master/encyclopedisque_importer.user.js)
+
+## <a name="ffm_importer"></a> <img src="assets/icons/typescript.svg" alt="TypeScript" width="16" height="16"> Import FFM releases to MusicBrainz
+
+Import ffm.to smart links with Harmony and add their remaining URL relationships to MusicBrainz
+
+[![Source](assets/buttons/button-source.svg)](https://github.com/murdos/musicbrainz-userscripts/blob/dist/ffm_importer.user.js)
+[![Install](assets/buttons/button-install.svg)](https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/ffm_importer.user.js)
 
 ## <a name="fma_importer"></a> Import FMA releases to MusicBrainz
 

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -40,6 +40,7 @@ const MetadataSchema = z.strictObject({
     downloadURL: z.string(),
     updateURL: z.string(),
     match: z.array(z.string()),
+    connect: z.array(z.string()).optional(),
     require: z.array(z.string()).optional(),
     grant: z.array(z.string()).optional(),
     runAt: z.string().optional(),
@@ -117,6 +118,12 @@ function generateUserscriptHeader(metadata: UserscriptMetadata): string {
     metadata.match.forEach(pattern => {
         lines.push(`@match        ${pattern}`);
     });
+
+    if (metadata.connect) {
+        metadata.connect.forEach(host => {
+            lines.push(`@connect      ${host}`);
+        });
+    }
 
     if (metadata.require) {
         metadata.require.forEach(url => {

--- a/src/types/userscript.d.ts
+++ b/src/types/userscript.d.ts
@@ -1,6 +1,12 @@
 // Userscript environment types
 declare global {
     const unsafeWindow: Window & typeof globalThis;
+    const GM_info: {
+        script: {
+            name: string;
+            version: string;
+        };
+    };
 }
 
 export {};

--- a/src/userscripts/ffm_importer/README.md
+++ b/src/userscripts/ffm_importer/README.md
@@ -1,0 +1,34 @@
+# FFM importer
+
+This userscript helps connect an `ffm.to` smart-link page to its MusicBrainz release. It can start a release import through Harmony and add provider URLs that are missing from an existing release.
+
+## How it works
+
+The importer runs in a few stages:
+
+1. It collects the music-service links rendered by FFM and resolves their final destinations. Destinations embedded in FFM's link data are decoded locally; other links are resolved by following their redirects.
+2. It asks the MusicBrainz URL web service which releases are related to any of those destinations.
+3. It continues only when exactly one release is found. No match leaves Harmony available for a new import, while multiple matches produce an ambiguity warning and disable the import actions.
+4. For a single match, it fetches that release with `url-rels`, compares every FFM destination with the current MusicBrainz relationships, and marks links that are already present. This step was only added to handle the region-specific URLs that MB Search cannot support yet, e.g. `https://music.apple.com/us/album/...` vs `https://music.apple.com/gb/album/...`. (https://tickets.metabrainz.org/browse/SEARCH-748)
+5. **Add Missing Links** opens the MusicBrainz release editor with all missing relationships prefilled. Harmony-supported services are included in this check because a previous Harmony import may not have added every URL.
+
+Resolved FFM destinations are cached in local storage to avoid repeatedly following redirects. MusicBrainz release lookup and relationship data are fetched fresh.
+
+### Example
+
+`https://ffm.to/buried-memories`
+→ resolve its Spotify, Bandcamp, and other provider URLs
+→ look those URLs up in MusicBrainz
+→ find `https://musicbrainz.org/release/c0a4bde9-8ec2-4ea8-aa9c-7d00c8aa6d30`
+→ compare the release's URL relationships and offer the missing Bandcamp link.
+
+If none of the provider URLs find a release, the page can instead be imported with Harmony. If the URLs point to different releases, the importer stops and reports the ambiguity.
+
+## Requests and modes
+
+The script makes read-only JSON requests to the MusicBrainz `/ws/2/url` and `/ws/2/release/{mbid}` endpoints. Adding links is not automatic: it opens a normal MusicBrainz edit form for review and submission.
+
+The panel can target either `musicbrainz.org` or `beta.musicbrainz.org`, and remembers the selected server. Its two actions are:
+
+- **Import with Harmony** — open Harmony using a preferred provider URL.
+- **Add Missing Links** — update the uniquely matched MusicBrainz release with the URLs that are not present.

--- a/src/userscripts/ffm_importer/index.ts
+++ b/src/userscripts/ffm_importer/index.ts
@@ -1,0 +1,538 @@
+import {
+    chooseHarmonyLink,
+    decodeFfmDestination,
+    extractReleaseUrlResources,
+    findCanonicallyMatchedLinkUrls,
+    findMissingLinks,
+    findReleaseMatches,
+    normalizeServiceName,
+    normalizeServiceUrl,
+    relationshipTypeFor,
+    type ReleaseMatch,
+    type ServiceLink,
+} from './logic';
+
+const PANEL_ID = 'ffm-mb-importer';
+const STYLE_ID = 'ffm-mb-importer-style';
+const CACHE_PREFIX = 'ffm-mb-importer:v1:';
+const SERVER_PREFERENCE_KEY = 'ffm-mb-importer:server';
+const HYDRATION_SETTLE_MS = 1_000;
+const MUSICBRAINZ_SERVERS = ['https://musicbrainz.org', 'https://beta.musicbrainz.org'] as const;
+
+type MusicBrainzServer = (typeof MUSICBRAINZ_SERVERS)[number];
+
+interface PageCache {
+    links: Record<string, ServiceLink>;
+}
+
+interface ServiceAnchor {
+    cacheKey: string;
+    element: HTMLAnchorElement;
+    service: string;
+    label: string;
+    action: string;
+    sourceUrl: string;
+}
+
+interface GmResponse {
+    finalUrl?: string;
+    responseURL?: string;
+    status: number;
+}
+
+interface GmRequestDetails {
+    method: string;
+    url: string;
+    timeout: number;
+    onload: (response: GmResponse) => void;
+    onerror: () => void;
+    ontimeout: () => void;
+}
+
+type GmRequest = (details: GmRequestDetails) => unknown;
+
+interface ImportPanel {
+    root: HTMLElement;
+    status: HTMLElement;
+    release: HTMLAnchorElement;
+    server: HTMLSelectElement;
+    harmonyButton: HTMLAnchorElement;
+    missingLinksButton: HTMLButtonElement;
+    missingLinksLabel: HTMLElement;
+}
+
+function pageCacheKey(): string {
+    return `${CACHE_PREFIX}${window.location.origin}${window.location.pathname.replace(/\/$/, '')}`;
+}
+
+function readPageCache(): PageCache {
+    try {
+        const parsed: unknown = JSON.parse(window.localStorage.getItem(pageCacheKey()) ?? 'null');
+        if (parsed && typeof parsed === 'object') {
+            const record = parsed as Record<string, unknown>;
+            if (record['links'] && typeof record['links'] === 'object') {
+                return { links: record['links'] as Record<string, ServiceLink> };
+            }
+        }
+    } catch {
+        // Ignore unavailable storage and obsolete/corrupt cache entries.
+    }
+    return { links: {} };
+}
+
+function savePageCache(cache: PageCache): void {
+    try {
+        window.localStorage.setItem(pageCacheKey(), JSON.stringify(cache));
+    } catch {
+        // The importer still works for this page load when storage is unavailable.
+    }
+}
+
+function readServerPreference(): MusicBrainzServer {
+    try {
+        const stored = window.localStorage.getItem(SERVER_PREFERENCE_KEY);
+        if (MUSICBRAINZ_SERVERS.includes(stored as MusicBrainzServer)) return stored as MusicBrainzServer;
+    } catch {
+        // Fall through to production.
+    }
+    return MUSICBRAINZ_SERVERS[0];
+}
+
+function saveServerPreference(server: MusicBrainzServer): void {
+    try {
+        window.localStorage.setItem(SERVER_PREFERENCE_KEY, server);
+    } catch {
+        // Preference persistence is optional.
+    }
+}
+
+function gmRequest(): GmRequest | undefined {
+    const userscriptGlobal = globalThis as typeof globalThis & {
+        GM?: { xmlHttpRequest?: GmRequest };
+        GM_xmlhttpRequest?: GmRequest;
+    };
+    return userscriptGlobal.GM?.xmlHttpRequest ?? userscriptGlobal.GM_xmlhttpRequest;
+}
+
+function followRedirect(sourceUrl: string): Promise<string> {
+    const request = gmRequest();
+    if (!request) return Promise.reject(new Error('No userscript cross-origin request API is available'));
+
+    return new Promise((resolve, reject) => {
+        const failed = (): void => {
+            reject(new Error(`Could not resolve ${sourceUrl}`));
+        };
+        request({
+            method: 'GET',
+            url: sourceUrl,
+            timeout: 20_000,
+            onload: response => {
+                const destination = response.finalUrl ?? response.responseURL;
+                if (response.status >= 200 && response.status < 400 && destination) resolve(destination);
+                else failed();
+            },
+            onerror: failed,
+            ontimeout: failed,
+        });
+    });
+}
+
+function collectServiceAnchors(): ServiceAnchor[] {
+    const counters = new Map<string, number>();
+    const anchors: ServiceAnchor[] = [];
+    for (const element of document.querySelectorAll<HTMLAnchorElement>('a[service][href]')) {
+        const rawService = element.getAttribute('service') ?? '';
+        const service = normalizeServiceName(rawService);
+        if (!service || !element.href) continue;
+
+        const count = (counters.get(service) ?? 0) + 1;
+        counters.set(service, count);
+        anchors.push({
+            cacheKey: count === 1 ? service : `${service}:${count}`,
+            element,
+            service,
+            label: element.querySelector<HTMLElement>('.service-title')?.textContent.trim() || rawService,
+            action: element.querySelector<HTMLElement>('.service-text')?.textContent.trim() || '',
+            sourceUrl: element.href,
+        });
+    }
+    return anchors;
+}
+
+function waitForServiceAnchors(): Promise<ServiceAnchor[]> {
+    return new Promise(resolve => {
+        let settleTimer: number | undefined;
+        let finished = false;
+
+        const finish = (anchors: ServiceAnchor[]): void => {
+            if (finished) return;
+            finished = true;
+            observer.disconnect();
+            if (settleTimer !== undefined) window.clearTimeout(settleTimer);
+            window.clearTimeout(maximumWaitTimer);
+            resolve(anchors);
+        };
+
+        const waitUntilStable = (): void => {
+            const anchors = collectServiceAnchors();
+            if (anchors.length === 0) return;
+
+            if (settleTimer !== undefined) window.clearTimeout(settleTimer);
+            settleTimer = window.setTimeout(() => {
+                const stableAnchors = collectServiceAnchors();
+                if (stableAnchors.length > 0) finish(stableAnchors);
+                else waitUntilStable();
+            }, HYDRATION_SETTLE_MS);
+        };
+
+        const observer = new MutationObserver(() => {
+            waitUntilStable();
+        });
+        const maximumWaitTimer = window.setTimeout(() => {
+            finish(collectServiceAnchors());
+        }, 20_000);
+        observer.observe(document.documentElement, { childList: true, subtree: true });
+        waitUntilStable();
+    });
+}
+
+async function resolveServiceLinks(anchors: ServiceAnchor[], cache: PageCache): Promise<ServiceLink[]> {
+    const resolved = await Promise.all(
+        anchors.map(async anchor => {
+            const cached = cache.links[anchor.cacheKey];
+            if (cached?.sourceUrl === anchor.sourceUrl) return cached;
+
+            try {
+                const decoded = decodeFfmDestination(anchor.sourceUrl);
+                if (cached && (!decoded || normalizeServiceUrl(decoded, anchor.service) === cached.url)) {
+                    const refreshed = {
+                        ...cached,
+                        label: anchor.label,
+                        action: anchor.action,
+                        sourceUrl: anchor.sourceUrl,
+                    };
+                    cache.links[anchor.cacheKey] = refreshed;
+                    return refreshed;
+                }
+                const destination = decoded ?? (await followRedirect(anchor.sourceUrl));
+                const link: ServiceLink = {
+                    service: anchor.service,
+                    label: anchor.label,
+                    action: anchor.action,
+                    sourceUrl: anchor.sourceUrl,
+                    url: normalizeServiceUrl(destination, anchor.service),
+                };
+                cache.links[anchor.cacheKey] = link;
+                return link;
+            } catch (error) {
+                console.warn(`FFM importer: could not resolve ${anchor.label}`, error);
+                return undefined;
+            }
+        }),
+    );
+    savePageCache(cache);
+    return resolved.filter(link => link !== undefined);
+}
+
+function lookupReleases(links: ServiceLink[], server: MusicBrainzServer): Promise<ReleaseMatch[]> {
+    const resources = [...new Set(links.map(link => link.url))];
+    if (resources.length === 0) return Promise.resolve([]);
+
+    const endpoint = new URL('/ws/2/url', server);
+    for (const resource of resources) endpoint.searchParams.append('resource', resource);
+    endpoint.searchParams.set('inc', 'release-rels');
+    endpoint.searchParams.set('fmt', 'json');
+
+    return fetch(endpoint, { headers: { Accept: 'application/json' } }).then(async response => {
+        if (!response.ok) throw new Error(`MusicBrainz URL lookup failed with HTTP ${response.status}`);
+        return findReleaseMatches(await response.json());
+    });
+}
+
+async function includeReleaseRelationships(links: ServiceLink[], server: MusicBrainzServer, match: ReleaseMatch): Promise<ReleaseMatch> {
+    const endpoint = new URL(`/ws/2/release/${match.releaseId}`, server);
+    endpoint.searchParams.set('inc', 'url-rels');
+    endpoint.searchParams.set('fmt', 'json');
+
+    const response = await fetch(endpoint, { headers: { Accept: 'application/json' } });
+    if (!response.ok) throw new Error(`MusicBrainz release lookup failed with HTTP ${response.status}`);
+    const resources = extractReleaseUrlResources(await response.json());
+    return { releaseId: match.releaseId, matchedUrls: findCanonicallyMatchedLinkUrls(links, resources) };
+}
+
+function addStyles(): void {
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = `
+        #${PANEL_ID} {
+            position: fixed;
+            top: 16px;
+            right: 16px;
+            z-index: 2147483646;
+            width: min(340px, calc(100vw - 32px));
+            max-height: calc(100vh - 32px);
+            overflow-y: auto;
+            box-sizing: border-box;
+            padding: 12px;
+            border-radius: 8px;
+            background: rgba(255, 255, 255, 0.96);
+            color: #222;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.22);
+            font: 13px/1.4 Arial, sans-serif;
+        }
+        @media (max-width: 720px) {
+            #${PANEL_ID} {
+                top: auto;
+                right: 8px;
+                bottom: 8px;
+                width: min(340px, calc(100vw - 16px));
+                max-height: 50vh;
+            }
+        }
+        #${PANEL_ID} .ffm-mb-heading,
+        #${PANEL_ID} .ffm-mb-controls,
+        #${PANEL_ID} .ffm-mb-buttons {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+        #${PANEL_ID} .ffm-mb-heading { font-weight: bold; margin-bottom: 8px; }
+        #${PANEL_ID} [hidden] { display: none !important; }
+        #${PANEL_ID} .ffm-mb-controls { margin: 8px 0; }
+        #${PANEL_ID} .ffm-mb-status { color: #555; }
+        #${PANEL_ID} .ffm-mb-release { color: #0875bd; font-weight: bold; }
+        #${PANEL_ID} .ffm-mb-button {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            min-height: 30px;
+            padding: 5px 10px;
+            box-sizing: border-box;
+            border: 1px solid #a7a7a7;
+            border-radius: 5px;
+            background: #f4f4f4;
+            color: #222;
+            cursor: pointer;
+            font: bold 12px Arial, sans-serif;
+            text-decoration: none;
+        }
+        #${PANEL_ID} .ffm-mb-button:hover:not(:disabled) { background: #fff; }
+        #${PANEL_ID} .ffm-mb-button:disabled { cursor: default; opacity: 0.55; }
+        #${PANEL_ID} .ffm-mb-button img { flex: none; }
+        a.ffm-mb-present { position: relative; outline: 3px solid #32a852 !important; }
+        a.ffm-mb-present::after {
+            content: '\u2713';
+            position: absolute;
+            top: -7px;
+            right: -7px;
+            width: 21px;
+            height: 21px;
+            border-radius: 25%;
+            background: #ba478f;
+            color: #fff;
+            font: bold 15px/21px Arial, sans-serif;
+            text-align: center;
+            z-index: 2;
+        }
+    `;
+    document.head.appendChild(style);
+}
+
+function createPanel(server: MusicBrainzServer): ImportPanel {
+    addStyles();
+    document.getElementById(PANEL_ID)?.remove();
+
+    const root = document.createElement('section');
+    root.id = PANEL_ID;
+    root.innerHTML = `
+        <div class="ffm-mb-heading">
+            <img src="https://musicbrainz.org/static/images/entity/release.svg" width="18" height="18" alt="" />
+            MusicBrainz release importer
+        </div>
+        <div class="ffm-mb-status">Resolving provider links…</div>
+        <div class="ffm-mb-controls">
+            <label>MusicBrainz server <select class="ffm-mb-server"></select></label>
+            <a class="ffm-mb-release" target="_blank" hidden></a>
+        </div>
+        <div class="ffm-mb-buttons">
+            <a class="ffm-mb-button ffm-mb-harmony" target="_blank" hidden>
+                <img src="https://harmony.pulsewidth.org.uk/favicon.svg" width="16" height="16" alt="" />
+                Import with Harmony
+            </a>
+            <button class="ffm-mb-button ffm-mb-missing" type="button" hidden>
+                <img src="https://raw.githubusercontent.com/metabrainz/design-system/master/brand/logos/MusicBrainz/SVG/MusicBrainz_logo_icon.svg" width="16" height="16" alt="" />
+                <span class="ffm-mb-missing-label">Add Missing Links</span>
+            </button>
+        </div>
+    `;
+
+    mountPanel(root);
+
+    const serverSelect = root.querySelector<HTMLSelectElement>('.ffm-mb-server')!;
+    for (const value of MUSICBRAINZ_SERVERS) {
+        const option = document.createElement('option');
+        option.value = value;
+        option.textContent = value === MUSICBRAINZ_SERVERS[0] ? 'musicbrainz.org' : 'beta.musicbrainz.org';
+        option.selected = value === server;
+        serverSelect.appendChild(option);
+    }
+
+    return {
+        root,
+        status: root.querySelector<HTMLElement>('.ffm-mb-status')!,
+        release: root.querySelector<HTMLAnchorElement>('.ffm-mb-release')!,
+        server: serverSelect,
+        harmonyButton: root.querySelector<HTMLAnchorElement>('.ffm-mb-harmony')!,
+        missingLinksButton: root.querySelector<HTMLButtonElement>('.ffm-mb-missing')!,
+        missingLinksLabel: root.querySelector<HTMLElement>('.ffm-mb-missing-label')!,
+    };
+}
+
+function mountPanel(root: HTMLElement): void {
+    const musicServices = document.querySelector('.music-services-section');
+    if (musicServices?.parentElement) musicServices.parentElement.insertBefore(root, musicServices);
+    else document.body.appendChild(root);
+}
+
+function keepPanelMounted(panel: ImportPanel, onRemount: () => void): void {
+    let remountScheduled = false;
+    const ensureMounted = (): void => {
+        if (panel.root.isConnected || remountScheduled) return;
+        remountScheduled = true;
+        window.setTimeout(() => {
+            remountScheduled = false;
+            if (panel.root.isConnected) return;
+            mountPanel(panel.root);
+            onRemount();
+        }, 250);
+    };
+    const observer = new MutationObserver(ensureMounted);
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    ensureMounted();
+}
+
+function markExistingLinks(anchors: ServiceAnchor[], links: ServiceLink[], matchedUrls: ReadonlySet<string>): void {
+    for (const anchor of anchors) {
+        const serviceMatches = links.filter(candidate => candidate.service === anchor.service);
+        const link = serviceMatches.find(candidate => candidate.sourceUrl === anchor.sourceUrl) ?? serviceMatches[0];
+        const present = link ? matchedUrls.has(link.url) : false;
+        anchor.element.classList.toggle('ffm-mb-present', present);
+        if (present) anchor.element.title = 'This URL is already linked to the MusicBrainz release';
+    }
+}
+
+function submitMissingLinks(server: MusicBrainzServer, releaseId: string, links: ServiceLink[]): void {
+    const form = document.createElement('form');
+    form.method = 'post';
+    form.action = `${server}/release/${releaseId}/edit`;
+    form.target = '_blank';
+    form.acceptCharset = 'UTF-8';
+    form.hidden = true;
+
+    const parameters: Array<[string, string]> = [
+        ['edit_note', `Added URL relationships from ${window.location.href.replace(/[?#].*$/, '')}`],
+        ['redirect_uri', `${server}/release/${releaseId}`],
+    ];
+    links.forEach((link, index) => {
+        parameters.push([`urls.${index}.link_type`, String(relationshipTypeFor(link))]);
+        parameters.push([`urls.${index}.url`, link.url]);
+    });
+    for (const [name, value] of parameters) {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = name;
+        input.value = value;
+        form.appendChild(input);
+    }
+    document.body.appendChild(form);
+    form.submit();
+    form.remove();
+}
+
+function configureHarmonyButton(panel: ImportPanel, links: ServiceLink[]): void {
+    const harmonyLink = chooseHarmonyLink(links);
+    if (!harmonyLink) return;
+    const harmonyUrl = new URL('https://harmony.pulsewidth.org.uk/release');
+    harmonyUrl.searchParams.set('category', 'preferred');
+    harmonyUrl.searchParams.set('url', harmonyLink.url);
+    panel.harmonyButton.href = harmonyUrl.toString();
+    panel.harmonyButton.title = `Import using ${harmonyLink.label}`;
+    panel.harmonyButton.hidden = false;
+}
+
+async function initialize(): Promise<void> {
+    if (document.getElementById(PANEL_ID)) return;
+    const server = readServerPreference();
+    const cache = readPageCache();
+    const anchors = await waitForServiceAnchors();
+    if (document.getElementById(PANEL_ID)) return;
+    const panel = createPanel(server);
+    if (anchors.length === 0) {
+        panel.status.textContent = 'No FFM provider links were found on this page.';
+        return;
+    }
+
+    const links = await resolveServiceLinks(anchors, cache);
+    panel.status.textContent = `Resolved ${links.length} of ${anchors.length} provider links. Checking MusicBrainz…`;
+    configureHarmonyButton(panel, links);
+
+    let lookupGeneration = 0;
+    const checkMusicBrainz = async (selectedServer: MusicBrainzServer): Promise<void> => {
+        const generation = ++lookupGeneration;
+        panel.status.textContent = `Resolved ${links.length} provider links. Checking MusicBrainz…`;
+        panel.release.hidden = true;
+        panel.missingLinksButton.hidden = true;
+        configureHarmonyButton(panel, links);
+        markExistingLinks(collectServiceAnchors(), links, new Set());
+
+        try {
+            const discoveredMatches = await lookupReleases(links, selectedServer);
+            if (generation !== lookupGeneration) return;
+            const discoveredMatch = discoveredMatches[0];
+            if (!discoveredMatch) {
+                panel.status.textContent = 'No existing MusicBrainz release found. Import with Harmony, then reload this page.';
+                return;
+            }
+            if (discoveredMatches.length > 1) {
+                panel.harmonyButton.hidden = true;
+                panel.status.textContent = `Ambiguous MusicBrainz match: these provider links belong to ${discoveredMatches.length} releases. No links can be added.`;
+                return;
+            }
+            const match = await includeReleaseRelationships(links, selectedServer, discoveredMatch);
+            if (generation !== lookupGeneration) return;
+
+            const matchedUrls = new Set(match.matchedUrls);
+            markExistingLinks(collectServiceAnchors(), links, matchedUrls);
+            panel.release.href = `${selectedServer}/release/${match.releaseId}`;
+            panel.release.textContent = 'View matched release';
+            panel.release.hidden = false;
+
+            const missing = findMissingLinks(links, matchedUrls);
+            panel.status.textContent = `${matchedUrls.size} provider link${matchedUrls.size === 1 ? '' : 's'} already present; ${missing.length} additional link${missing.length === 1 ? '' : 's'} available.`;
+            panel.missingLinksButton.hidden = false;
+            panel.missingLinksButton.disabled = missing.length === 0;
+            panel.missingLinksLabel.textContent = missing.length === 0 ? 'All Links Present' : 'Add Missing Links';
+            panel.missingLinksButton.onclick = () => {
+                submitMissingLinks(selectedServer, match.releaseId, missing);
+            };
+        } catch (error) {
+            if (generation !== lookupGeneration) return;
+            console.error('FFM importer: MusicBrainz lookup failed', error);
+            panel.status.textContent = 'MusicBrainz lookup failed. Reload the page to try again.';
+        }
+    };
+
+    panel.server.addEventListener('change', () => {
+        const selectedServer = panel.server.value as MusicBrainzServer;
+        saveServerPreference(selectedServer);
+        void checkMusicBrainz(selectedServer);
+    });
+    keepPanelMounted(panel, () => {
+        void checkMusicBrainz(panel.server.value as MusicBrainzServer);
+    });
+    await checkMusicBrainz(server);
+}
+
+void initialize();

--- a/src/userscripts/ffm_importer/index.ts
+++ b/src/userscripts/ffm_importer/index.ts
@@ -432,7 +432,10 @@ function submitMissingLinks(server: MusicBrainzServer, releaseId: string, links:
     form.hidden = true;
 
     const parameters: Array<[string, string]> = [
-        ['edit_note', `Added URL relationships from ${window.location.href.replace(/[?#].*$/, '')}`],
+        [
+            'edit_note',
+            `Added URL relationships from ${window.location.href.replace(/[?#].*$/, '')}\n\nUsing '''${GM_info.script.name}''' ${GM_info.script.version} from https://github.com/murdos/musicbrainz-userscripts`,
+        ],
         ['redirect_uri', `${server}/release/${releaseId}`],
     ];
     links.forEach((link, index) => {

--- a/src/userscripts/ffm_importer/logic.ts
+++ b/src/userscripts/ffm_importer/logic.ts
@@ -1,6 +1,7 @@
 export const HARMONY_SERVICE_PREFERENCE = ['spotify', 'tidal', 'deezer', 'bandcamp', 'apple', 'itunes'] as const;
 
 export const URL_RELATIONSHIP_TYPES = {
+    asin: 77,
     purchaseForDownload: 74,
     downloadForFree: 75,
     otherDatabases: 82,
@@ -125,6 +126,20 @@ function hostnameMatches(url: URL, domain: string): boolean {
     return url.hostname === domain || url.hostname.endsWith(`.${domain}`);
 }
 
+function amazonAsinFromUrl(rawUrl: string): string | undefined {
+    try {
+        const url = new URL(rawUrl);
+        if (!/(^|\.)amazon\.[a-z]{2,}(\.[a-z]{2})?$/i.test(url.hostname)) return undefined;
+
+        const parts = url.pathname.split('/').filter(Boolean);
+        const asinIndex = parts.findIndex((part, index) => /^(dp|product)$/i.test(part) && index < parts.length - 1);
+        const asin = asinIndex >= 0 ? parts[asinIndex + 1] : undefined;
+        return asin && /^[A-Z0-9]{10}$/i.test(asin) ? asin.toUpperCase() : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
 /** Identify the provider entity represented by a URL while ignoring storefront and tracking differences. */
 export function canonicalServiceUrlKey(rawUrl: string, rawService: string): string {
     const service = normalizeServiceName(rawService);
@@ -151,9 +166,14 @@ export function canonicalServiceUrlKey(rawUrl: string, rawService: string): stri
                 providerId = pathValueAfter(url, 'album');
                 return providerId ? `${service}:album:${providerId}` : normalizeServiceUrl(rawUrl, service);
             case 'amazon':
+            case 'amazonstore': {
+                const asin = amazonAsinFromUrl(rawUrl);
+                if (asin) return `amazon:asin:${asin}`;
+                if (service === 'amazonstore') return normalizeServiceUrl(rawUrl, service);
                 if (!url.hostname.startsWith('music.amazon.')) return rawUrl;
                 providerId = pathValueAfter(url, 'albums');
                 return providerId ? `amazon:album:${providerId}` : normalizeServiceUrl(rawUrl, service);
+            }
             case 'youtube':
             case 'youtubemusic':
                 if (!hostnameMatches(url, 'youtube.com')) return rawUrl;
@@ -209,6 +229,7 @@ export function chooseHarmonyLink(links: ServiceLink[]): ServiceLink | undefined
 export function relationshipTypeFor(link: ServiceLink): number {
     const action = link.action.toLowerCase();
     const service = normalizeServiceName(link.service);
+    if (amazonAsinFromUrl(link.url)) return URL_RELATIONSHIP_TYPES.asin;
     if (action.includes('free') && action.includes('download')) return URL_RELATIONSHIP_TYPES.downloadForFree;
     if (action.includes('buy') || action.includes('download') || ['amazonstore', 'beatport', 'junodownload'].includes(service)) {
         return URL_RELATIONSHIP_TYPES.purchaseForDownload;

--- a/src/userscripts/ffm_importer/logic.ts
+++ b/src/userscripts/ffm_importer/logic.ts
@@ -1,0 +1,258 @@
+export const HARMONY_SERVICE_PREFERENCE = ['spotify', 'tidal', 'deezer', 'bandcamp', 'apple', 'itunes'] as const;
+
+export const URL_RELATIONSHIP_TYPES = {
+    purchaseForDownload: 74,
+    downloadForFree: 75,
+    otherDatabases: 82,
+    streamForFree: 85,
+    streaming: 980,
+} as const;
+
+export interface ServiceLink {
+    service: string;
+    label: string;
+    action: string;
+    sourceUrl: string;
+    url: string;
+}
+
+export interface ReleaseMatch {
+    releaseId: string;
+    matchedUrls: string[];
+}
+
+export interface ReleaseUrlRelation {
+    url?: { resource?: string };
+}
+
+function findStringProperty(value: unknown, names: ReadonlySet<string>): string | undefined {
+    if (!value || typeof value !== 'object') return undefined;
+
+    for (const [key, child] of Object.entries(value)) {
+        if (names.has(key.toLowerCase()) && typeof child === 'string') return child;
+    }
+    for (const child of Object.values(value)) {
+        const found = findStringProperty(child, names);
+        if (found) return found;
+    }
+    return undefined;
+}
+
+/** Extract the destination URL carried in an FFM `cd` tracking payload. */
+export function decodeFfmDestination(sourceUrl: string): string | undefined {
+    try {
+        const encoded = new URL(sourceUrl).searchParams.get('cd');
+        if (!encoded) return undefined;
+
+        const base64 = encoded
+            .replaceAll('-', '+')
+            .replaceAll('_', '/')
+            .padEnd(Math.ceil(encoded.length / 4) * 4, '=');
+        const binary = atob(base64);
+        const bytes = Uint8Array.from(binary, character => character.charCodeAt(0));
+        const payload: unknown = JSON.parse(new TextDecoder().decode(bytes));
+        return findStringProperty(payload, new Set(['desturl', 'destinationurl', 'destination']));
+    } catch {
+        return undefined;
+    }
+}
+
+export function normalizeServiceName(service: string): string {
+    const normalized = service
+        .trim()
+        .toLowerCase()
+        .replaceAll(/[^a-z0-9]/g, '');
+    if (normalized === 'applemusic') return 'apple';
+    if (normalized === 'amazonmusic') return 'amazon';
+    if (normalized === 'ytmusic') return 'youtubemusic';
+    return normalized;
+}
+
+function removeTrackingParameters(url: URL): void {
+    const trackingNames = new Set(['at', 'ct', 'ffm', 'lid', 'ref', 'ref_', 'src', 'tag']);
+    for (const name of [...url.searchParams.keys()]) {
+        if (name.toLowerCase().startsWith('utm_') || trackingNames.has(name.toLowerCase())) {
+            url.searchParams.delete(name);
+        }
+    }
+}
+
+/** Produce stable provider URLs suitable for Harmony and exact MusicBrainz URL lookup. */
+export function normalizeServiceUrl(rawUrl: string, rawService: string): string {
+    const service = normalizeServiceName(rawService);
+    const url = new URL(rawUrl);
+
+    const nestedPandoraUrl = url.searchParams.get('$desktop_url');
+    if (nestedPandoraUrl) return normalizeServiceUrl(nestedPandoraUrl, 'pandora');
+
+    url.protocol = 'https:';
+    url.hash = '';
+
+    if (service === 'apple' || service === 'itunes') {
+        url.hostname = 'music.apple.com';
+        url.search = '';
+    } else if (service === 'spotify') {
+        url.hostname = 'open.spotify.com';
+        url.search = '';
+    } else if (service === 'tidal') {
+        url.hostname = 'tidal.com';
+        url.search = '';
+    } else if (service === 'deezer') {
+        url.hostname = 'www.deezer.com';
+        url.pathname = url.pathname.replace(/^\/[a-z]{2}\/album\//i, '/album/');
+        url.search = '';
+    } else if (service === 'youtube' || service === 'youtubemusic') {
+        const list = url.searchParams.get('list');
+        const video = url.searchParams.get('v');
+        url.search = '';
+        if (list) url.searchParams.set('list', list);
+        if (!list && video) url.searchParams.set('v', video);
+    } else {
+        removeTrackingParameters(url);
+    }
+
+    return url.toString();
+}
+
+function pathValueAfter(url: URL, segment: string): string | undefined {
+    const parts = url.pathname.split('/').filter(Boolean);
+    const segmentIndex = parts.indexOf(segment);
+    if (segmentIndex < 0) return undefined;
+    return parts.at(-1);
+}
+
+function hostnameMatches(url: URL, domain: string): boolean {
+    return url.hostname === domain || url.hostname.endsWith(`.${domain}`);
+}
+
+/** Identify the provider entity represented by a URL while ignoring storefront and tracking differences. */
+export function canonicalServiceUrlKey(rawUrl: string, rawService: string): string {
+    const service = normalizeServiceName(rawService);
+    try {
+        const url = new URL(rawUrl);
+        let providerId: string | undefined;
+
+        switch (service) {
+            case 'apple':
+            case 'itunes':
+                if (!hostnameMatches(url, 'apple.com')) return rawUrl;
+                providerId = pathValueAfter(url, 'album');
+                return providerId ? `apple:album:${providerId}` : normalizeServiceUrl(rawUrl, service);
+            case 'spotify':
+                if (!hostnameMatches(url, 'spotify.com')) return rawUrl;
+                providerId = pathValueAfter(url, 'album');
+                return providerId ? `${service}:album:${providerId}` : normalizeServiceUrl(rawUrl, service);
+            case 'tidal':
+                if (!hostnameMatches(url, 'tidal.com')) return rawUrl;
+                providerId = pathValueAfter(url, 'album');
+                return providerId ? `${service}:album:${providerId}` : normalizeServiceUrl(rawUrl, service);
+            case 'deezer':
+                if (!hostnameMatches(url, 'deezer.com')) return rawUrl;
+                providerId = pathValueAfter(url, 'album');
+                return providerId ? `${service}:album:${providerId}` : normalizeServiceUrl(rawUrl, service);
+            case 'amazon':
+                if (!url.hostname.startsWith('music.amazon.')) return rawUrl;
+                providerId = pathValueAfter(url, 'albums');
+                return providerId ? `amazon:album:${providerId}` : normalizeServiceUrl(rawUrl, service);
+            case 'youtube':
+            case 'youtubemusic':
+                if (!hostnameMatches(url, 'youtube.com')) return rawUrl;
+                providerId = url.searchParams.get('list') ?? undefined;
+                return providerId ? `${service}:playlist:${providerId}` : normalizeServiceUrl(rawUrl, service);
+            case 'qobuz':
+                if (!hostnameMatches(url, 'qobuz.com')) return rawUrl;
+                providerId = pathValueAfter(url, 'album');
+                return providerId ? `qobuz:album:${providerId}` : normalizeServiceUrl(rawUrl, service);
+            default:
+                return normalizeServiceUrl(rawUrl, service);
+        }
+    } catch {
+        return rawUrl;
+    }
+}
+
+export function extractReleaseUrlResources(response: unknown): string[] {
+    if (!response || typeof response !== 'object') return [];
+    const relations = (response as Record<string, unknown>)['relations'];
+    if (!Array.isArray(relations)) return [];
+
+    const resources: string[] = [];
+    for (const relation of relations as ReleaseUrlRelation[]) {
+        const resource = relation.url?.resource;
+        if (resource) resources.push(resource);
+    }
+    return resources;
+}
+
+export function findCanonicallyMatchedLinkUrls(links: ServiceLink[], releaseResources: string[]): string[] {
+    return links
+        .filter(link => {
+            const linkKey = canonicalServiceUrlKey(link.url, link.service);
+            return releaseResources.some(resource => canonicalServiceUrlKey(resource, link.service) === linkKey);
+        })
+        .map(link => link.url);
+}
+
+/** Return every resolved provider link that is not linked to the matched release. */
+export function findMissingLinks(links: ServiceLink[], matchedUrls: ReadonlySet<string>): ServiceLink[] {
+    return links.filter(link => !matchedUrls.has(link.url));
+}
+
+export function chooseHarmonyLink(links: ServiceLink[]): ServiceLink | undefined {
+    for (const preferredService of HARMONY_SERVICE_PREFERENCE) {
+        const match = links.find(link => normalizeServiceName(link.service) === preferredService);
+        if (match) return match;
+    }
+    return undefined;
+}
+
+export function relationshipTypeFor(link: ServiceLink): number {
+    const action = link.action.toLowerCase();
+    const service = normalizeServiceName(link.service);
+    if (action.includes('free') && action.includes('download')) return URL_RELATIONSHIP_TYPES.downloadForFree;
+    if (action.includes('buy') || action.includes('download') || ['amazonstore', 'beatport', 'junodownload'].includes(service)) {
+        return URL_RELATIONSHIP_TYPES.purchaseForDownload;
+    }
+    if (['amazon', 'apple', 'itunes', 'pandora', 'qobuz', 'tidal', 'youtubemusic'].includes(service)) {
+        return URL_RELATIONSHIP_TYPES.streaming;
+    }
+    if (action.includes('play') || action.includes('listen') || action.includes('stream')) {
+        return URL_RELATIONSHIP_TYPES.streamForFree;
+    }
+    return URL_RELATIONSHIP_TYPES.otherDatabases;
+}
+
+function readReleaseIds(relations: unknown): string[] {
+    if (!Array.isArray(relations)) return [];
+    const ids: string[] = [];
+    for (const relation of relations) {
+        if (!relation || typeof relation !== 'object') continue;
+        const release = (relation as Record<string, unknown>)['release'];
+        if (!release || typeof release !== 'object') continue;
+        const id = (release as Record<string, unknown>)['id'];
+        if (typeof id === 'string') ids.push(id);
+    }
+    return ids;
+}
+
+/** Collect every release matched by any of the queried provider URLs. */
+export function findReleaseMatches(response: unknown): ReleaseMatch[] {
+    if (!response || typeof response !== 'object') return [];
+    const record = response as Record<string, unknown>;
+    const urlEntries = Array.isArray(record['urls']) ? record['urls'] : [record];
+    const matches = new Map<string, Set<string>>();
+
+    for (const entry of urlEntries) {
+        if (!entry || typeof entry !== 'object') continue;
+        const urlRecord = entry as Record<string, unknown>;
+        const resource = urlRecord['resource'];
+        if (typeof resource !== 'string') continue;
+        for (const releaseId of readReleaseIds(urlRecord['relations'])) {
+            const resources = matches.get(releaseId) ?? new Set<string>();
+            resources.add(resource);
+            matches.set(releaseId, resources);
+        }
+    }
+
+    return [...matches].map(([releaseId, resources]) => ({ releaseId, matchedUrls: [...resources] }));
+}

--- a/src/userscripts/ffm_importer/meta.json
+++ b/src/userscripts/ffm_importer/meta.json
@@ -1,0 +1,14 @@
+{
+    "name": "Import FFM releases to MusicBrainz",
+    "description": "Import ffm.to smart links with Harmony and add their remaining URL relationships to MusicBrainz",
+    "version": "2026.08.06.1",
+    "author": "Raman Sinclair",
+    "namespace": "https://github.com/murdos/musicbrainz-userscripts/",
+    "downloadURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/ffm_importer.user.js",
+    "updateURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/ffm_importer.user.js",
+    "match": ["https://ffm.to/*", "https://www.ffm.to/*"],
+    "connect": ["*"],
+    "grant": ["GM.xmlHttpRequest", "GM_xmlhttpRequest"],
+    "runAt": "document-idle",
+    "icon": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png"
+}

--- a/tests/ffm_importer/logic.test.ts
+++ b/tests/ffm_importer/logic.test.ts
@@ -46,6 +46,12 @@ describe('FFM importer logic', () => {
         expect(findCanonicallyMatchedLinkUrls(links, [musicBrainzAppleUrl])).toEqual([ffmAppleUrl, ffmAppleUrl]);
     });
 
+    it('matches equivalent Amazon product URLs by ASIN', () => {
+        expect(canonicalServiceUrlKey('https://www.amazon.com/gp/product/B0H47BDZJR', 'amazonstore')).toBe(
+            canonicalServiceUrlKey('https://amazon.com/dp/B0H47BDZJR', 'amazonstore'),
+        );
+    });
+
     it('extracts URL resources from a release lookup', () => {
         expect(
             extractReleaseUrlResources({
@@ -83,6 +89,9 @@ describe('FFM importer logic', () => {
         expect(relationshipTypeFor(serviceLink('qobuz'))).toBe(URL_RELATIONSHIP_TYPES.streaming);
         expect(relationshipTypeFor(serviceLink('qobuz', undefined, 'Buy'))).toBe(URL_RELATIONSHIP_TYPES.purchaseForDownload);
         expect(relationshipTypeFor(serviceLink('archive', undefined, 'Free download'))).toBe(URL_RELATIONSHIP_TYPES.downloadForFree);
+        expect(relationshipTypeFor(serviceLink('amazonstore', 'https://www.amazon.com/gp/product/B0H47BDZJR', 'Buy'))).toBe(
+            URL_RELATIONSHIP_TYPES.asin,
+        );
     });
 
     it('collects every release matched by the provider URLs so ambiguity is visible', () => {

--- a/tests/ffm_importer/logic.test.ts
+++ b/tests/ffm_importer/logic.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    chooseHarmonyLink,
+    canonicalServiceUrlKey,
+    decodeFfmDestination,
+    extractReleaseUrlResources,
+    findCanonicallyMatchedLinkUrls,
+    findMissingLinks,
+    findReleaseMatches,
+    normalizeServiceUrl,
+    relationshipTypeFor,
+    URL_RELATIONSHIP_TYPES,
+    type ServiceLink,
+} from '../../src/userscripts/ffm_importer/logic';
+
+function serviceLink(service: string, url = `https://example.com/${service}`, action = 'Play'): ServiceLink {
+    return { service, label: service, action, sourceUrl: 'https://api.ffm.to/link', url };
+}
+
+describe('FFM importer logic', () => {
+    it('decodes the destination from an FFM cd payload', () => {
+        const payload = Buffer.from(JSON.stringify({ product: 'smartlink', destUrl: 'https://open.spotify.com/album/abc123' })).toString(
+            'base64url',
+        );
+        expect(decodeFfmDestination(`https://api.ffm.to/sl/e/c/example?cd=${payload}`)).toBe('https://open.spotify.com/album/abc123');
+    });
+
+    it('normalizes provider URLs and removes FFM tracking', () => {
+        expect(
+            normalizeServiceUrl('https://geo.music.apple.com/au/album/buried-memories-single/6791224822?app=music&ls=1&ct=FFM', 'apple'),
+        ).toBe('https://music.apple.com/au/album/buried-memories-single/6791224822');
+        expect(normalizeServiceUrl('https://www.youtube.com/playlist?list=OLAK5uy_example&src=FFM&lid=tracking', 'youtube')).toBe(
+            'https://www.youtube.com/playlist?list=OLAK5uy_example',
+        );
+        expect(normalizeServiceUrl('http://www.tidal.com/album/543361480', 'tidal')).toBe('https://tidal.com/album/543361480');
+    });
+
+    it('matches regional Apple URLs by album ID', () => {
+        const ffmAppleUrl = 'https://music.apple.com/pl/album/marine-single/6793254042';
+        const musicBrainzAppleUrl = 'https://music.apple.com/us/album/6793254042';
+        expect(canonicalServiceUrlKey(ffmAppleUrl, 'apple')).toBe('apple:album:6793254042');
+        expect(canonicalServiceUrlKey(musicBrainzAppleUrl, 'itunes')).toBe('apple:album:6793254042');
+
+        const links = [serviceLink('apple', ffmAppleUrl), serviceLink('itunes', ffmAppleUrl, 'Download')];
+        expect(findCanonicallyMatchedLinkUrls(links, [musicBrainzAppleUrl])).toEqual([ffmAppleUrl, ffmAppleUrl]);
+    });
+
+    it('extracts URL resources from a release lookup', () => {
+        expect(
+            extractReleaseUrlResources({
+                relations: [
+                    { targetType: 'url', url: { resource: 'https://music.apple.com/us/album/6793254042' } },
+                    { targetType: 'artist', artist: { id: 'example' } },
+                ],
+            }),
+        ).toEqual(['https://music.apple.com/us/album/6793254042']);
+    });
+
+    it('includes missing Harmony-supported services in links to add', () => {
+        const spotify = serviceLink('spotify', 'https://open.spotify.com/album/example');
+        const bandcamp = serviceLink('bandcamp', 'https://example.bandcamp.com/album/example', 'Buy');
+
+        expect(findMissingLinks([spotify, bandcamp], new Set([spotify.url]))).toEqual([bandcamp]);
+    });
+
+    it('unwraps Pandora desktop destinations', () => {
+        const desktopUrl = 'https://www.pandora.com/artist/example/album/AL:123';
+        const branchUrl = `https://pandora.app.link/?$desktop_url=${encodeURIComponent(desktopUrl)}`;
+        expect(normalizeServiceUrl(branchUrl, 'pandora')).toBe(desktopUrl);
+    });
+
+    it('selects Harmony providers in the requested order', () => {
+        const links = [serviceLink('apple'), serviceLink('tidal'), serviceLink('spotify')];
+        expect(chooseHarmonyLink(links)?.service).toBe('spotify');
+        expect(chooseHarmonyLink(links.slice(0, 2))?.service).toBe('tidal');
+    });
+
+    it('maps service actions to MusicBrainz URL relationship types', () => {
+        expect(relationshipTypeFor(serviceLink('youtube'))).toBe(URL_RELATIONSHIP_TYPES.streamForFree);
+        expect(relationshipTypeFor(serviceLink('amazon'))).toBe(URL_RELATIONSHIP_TYPES.streaming);
+        expect(relationshipTypeFor(serviceLink('youtubemusic'))).toBe(URL_RELATIONSHIP_TYPES.streaming);
+        expect(relationshipTypeFor(serviceLink('qobuz'))).toBe(URL_RELATIONSHIP_TYPES.streaming);
+        expect(relationshipTypeFor(serviceLink('qobuz', undefined, 'Buy'))).toBe(URL_RELATIONSHIP_TYPES.purchaseForDownload);
+        expect(relationshipTypeFor(serviceLink('archive', undefined, 'Free download'))).toBe(URL_RELATIONSHIP_TYPES.downloadForFree);
+    });
+
+    it('collects every release matched by the provider URLs so ambiguity is visible', () => {
+        const releaseA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        const releaseB = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        const response = {
+            urls: [
+                {
+                    resource: 'https://example.com/spotify',
+                    relations: [{ release: { id: releaseA } }, { release: { id: releaseB } }],
+                },
+                {
+                    resource: 'https://example.com/deezer',
+                    relations: [{ release: { id: releaseA } }],
+                },
+            ],
+        };
+        expect(findReleaseMatches(response)).toEqual([
+            {
+                releaseId: releaseA,
+                matchedUrls: ['https://example.com/spotify', 'https://example.com/deezer'],
+            },
+            {
+                releaseId: releaseB,
+                matchedUrls: ['https://example.com/spotify'],
+            },
+        ]);
+    });
+});


### PR DESCRIPTION
Add an importer for matching FFM smart links with MusicBrainz releases and reviewing missing provider relationships.

Support Harmony imports, production and beta MusicBrainz, and safe handling of ambiguous release matches.

Test URL: https://ffm.to/buried-memories

Screenshot:
<img width="1331" height="1269" alt="image" src="https://github.com/user-attachments/assets/c7b3167b-ca96-441e-921c-5c213bddb75b" />
