### PR TITLE
perf(ffm_importer): don't recreate the tracking params set upon each function call

### DIFF
--- a/src/userscripts/ffm_importer/logic.ts
+++ b/src/userscripts/ffm_importer/logic.ts
@@ -1,5 +1,7 @@
 export const HARMONY_SERVICE_PREFERENCE = ['spotify', 'tidal', 'deezer', 'bandcamp', 'apple', 'itunes'] as const;
 
+const TRACKING_PARAMETER_NAMES = new Set(['at', 'ct', 'ffm', 'lid', 'ref', 'ref_', 'src', 'tag']);
+
 export const URL_RELATIONSHIP_TYPES = {
     asin: 77,
     purchaseForDownload: 74,
@@ -70,9 +72,8 @@ export function normalizeServiceName(service: string): string {
 }
 
 function removeTrackingParameters(url: URL): void {
-    const trackingNames = new Set(['at', 'ct', 'ffm', 'lid', 'ref', 'ref_', 'src', 'tag']);
     for (const name of [...url.searchParams.keys()]) {
-        if (name.toLowerCase().startsWith('utm_') || trackingNames.has(name.toLowerCase())) {
+        if (name.toLowerCase().startsWith('utm_') || TRACKING_PARAMETER_NAMES.has(name.toLowerCase())) {
             url.searchParams.delete(name);
         }
     }


### PR DESCRIPTION
- this trivial fix is only needed to test the version auto-increment CI