### PR TITLE
feat(ffm_importer): match subdomains too

### DIFF
--- a/src/userscripts/ffm_importer/README.md
+++ b/src/userscripts/ffm_importer/README.md
@@ -2,6 +2,8 @@
 
 This userscript helps connect an `ffm.to` smart-link page to its MusicBrainz release. It can start a release import through Harmony and add provider URLs that are missing from an existing release.
 
+It supports both `ffm.to` and branded subdomains such as `label-caster.ffm.to`.
+
 ## How it works
 
 The importer runs in a few stages:

--- a/src/userscripts/ffm_importer/meta.json
+++ b/src/userscripts/ffm_importer/meta.json
@@ -6,7 +6,7 @@
     "namespace": "https://github.com/murdos/musicbrainz-userscripts/",
     "downloadURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/ffm_importer.user.js",
     "updateURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/ffm_importer.user.js",
-    "match": ["https://ffm.to/*", "https://www.ffm.to/*"],
+    "match": ["https://ffm.to/*", "https://*.ffm.to/*"],
     "connect": ["*"],
     "grant": ["GM.xmlHttpRequest", "GM_xmlhttpRequest"],
     "runAt": "document-idle",


### PR DESCRIPTION
- e.g. https://label-caster.ffm.to/2xzm21zook