### PR TITLE
fix(ffm_importer): support converting new Boomplay URL format to the old format

### DIFF
--- a/src/userscripts/ffm_importer/index.ts
+++ b/src/userscripts/ffm_importer/index.ts
@@ -9,6 +9,7 @@ import {
     normalizeServiceName,
     normalizeServiceUrl,
     relationshipTypeFor,
+    resolveLegacyBoomplayResources,
     type ReleaseMatch,
     type ServiceLink,
 } from './logic';
@@ -257,7 +258,10 @@ async function includeReleaseRelationships(links: ServiceLink[], server: MusicBr
 
     const response = await fetch(endpoint, { headers: { Accept: 'application/json' } });
     if (!response.ok) throw new Error(`MusicBrainz release lookup failed with HTTP ${response.status}`);
-    const resources = extractReleaseUrlResources(await response.json());
+    let resources = extractReleaseUrlResources(await response.json());
+    if (links.some(link => normalizeServiceName(link.service) === 'boomplay')) {
+        resources = await resolveLegacyBoomplayResources(resources, followRedirect);
+    }
     return { releaseId: match.releaseId, matchedUrls: findCanonicallyMatchedLinkUrls(links, resources) };
 }
 

--- a/src/userscripts/ffm_importer/logic.ts
+++ b/src/userscripts/ffm_importer/logic.ts
@@ -110,6 +110,9 @@ export function normalizeServiceUrl(rawUrl: string, rawService: string): string 
         url.hostname = 'www.deezer.com';
         url.pathname = url.pathname.replace(/^\/[a-z]{2}\/album\//i, '/album/');
         url.search = '';
+    } else if (service === 'boomplay') {
+        url.hostname = 'www.boomplay.com';
+        url.search = '';
     } else if (service === 'youtube' || service === 'youtubemusic') {
         const list = url.searchParams.get('list');
         const video = url.searchParams.get('v');
@@ -219,6 +222,29 @@ export function findCanonicallyMatchedLinkUrls(links: ServiceLink[], releaseReso
             return releaseResources.some(resource => canonicalServiceUrlKey(resource, link.service) === linkKey);
         })
         .map(link => link.url);
+}
+
+function isLegacyBoomplayAlbumUrl(rawUrl: string): boolean {
+    try {
+        const url = new URL(rawUrl);
+        return hostnameMatches(url, 'boomplay.com') && /^\/albums\/\d+\/?$/.test(url.pathname);
+    } catch {
+        return false;
+    }
+}
+
+/** Follow legacy numeric Boomplay album URLs to their current opaque identifiers. */
+export async function resolveLegacyBoomplayResources(resources: string[], resolveUrl: (url: string) => Promise<string>): Promise<string[]> {
+    return Promise.all(
+        resources.map(async resource => {
+            if (!isLegacyBoomplayAlbumUrl(resource)) return resource;
+            try {
+                return await resolveUrl(resource);
+            } catch {
+                return resource;
+            }
+        }),
+    );
 }
 
 /** Return every resolved provider link that is not linked to the matched release. */

--- a/tests/ffm_importer/logic.test.ts
+++ b/tests/ffm_importer/logic.test.ts
@@ -11,6 +11,7 @@ import {
     isIgnoredService,
     normalizeServiceUrl,
     relationshipTypeFor,
+    resolveLegacyBoomplayResources,
     URL_RELATIONSHIP_TYPES,
     type ServiceLink,
 } from '../../src/userscripts/ffm_importer/logic';
@@ -35,6 +36,12 @@ describe('FFM importer logic', () => {
             'https://www.youtube.com/playlist?list=OLAK5uy_example',
         );
         expect(normalizeServiceUrl('http://www.tidal.com/album/543361480', 'tidal')).toBe('https://tidal.com/album/543361480');
+        expect(
+            normalizeServiceUrl(
+                'https://www.boomplay.com/albums/EQUABbK_Gy8KOODzT4ow4hGX?srModel=openapi_featurefm&ffm=FFM_example',
+                'boomplay',
+            ),
+        ).toBe('https://www.boomplay.com/albums/EQUABbK_Gy8KOODzT4ow4hGX');
     });
 
     it('matches regional Apple URLs by album ID', () => {
@@ -51,6 +58,21 @@ describe('FFM importer logic', () => {
         expect(canonicalServiceUrlKey('https://www.amazon.com/gp/product/B0H47BDZJR', 'amazonstore')).toBe(
             canonicalServiceUrlKey('https://amazon.com/dp/B0H47BDZJR', 'amazonstore'),
         );
+    });
+
+    it('matches current Boomplay links to legacy numeric MusicBrainz URLs through redirects', async () => {
+        const legacyUrl = 'https://www.boomplay.com/albums/134155234';
+        const currentUrl = 'https://www.boomplay.com/albums/EQUABbK_Gy8KOODzT4ow4hGX';
+        const unrelatedUrl = 'https://open.spotify.com/album/example';
+        const resources = await resolveLegacyBoomplayResources([legacyUrl, unrelatedUrl], url => {
+            expect(url).toBe(legacyUrl);
+            return Promise.resolve(currentUrl);
+        });
+
+        expect(resources).toEqual([currentUrl, unrelatedUrl]);
+        expect(findCanonicallyMatchedLinkUrls([serviceLink('boomplay', `${currentUrl}?ffm=tracking`)], resources)).toEqual([
+            `${currentUrl}?ffm=tracking`,
+        ]);
     });
 
     it('extracts URL resources from a release lookup', () => {


### PR DESCRIPTION
- this is needed only until MB supports the new format
- old format: https://www.boomplay.com/albums/134155234
- new format: https://www.boomplay.com/albums/EQUABbK_Gy8KOODzT4ow4hGX