### PR TITLE
fix(ffm_importer): fix Boomplay URL matching in FFM importer

### DIFF
--- a/src/userscripts/ffm_importer/index.ts
+++ b/src/userscripts/ffm_importer/index.ts
@@ -1,6 +1,7 @@
 import {
     chooseHarmonyLink,
     decodeFfmDestination,
+    expandLegacyBoomplayResources,
     extractReleaseUrlResources,
     findCanonicallyMatchedLinkUrls,
     findMissingLinks,
@@ -9,7 +10,6 @@ import {
     normalizeServiceName,
     normalizeServiceUrl,
     relationshipTypeFor,
-    resolveLegacyBoomplayResources,
     type ReleaseMatch,
     type ServiceLink,
 } from './logic';
@@ -260,7 +260,7 @@ async function includeReleaseRelationships(links: ServiceLink[], server: MusicBr
     if (!response.ok) throw new Error(`MusicBrainz release lookup failed with HTTP ${response.status}`);
     let resources = extractReleaseUrlResources(await response.json());
     if (links.some(link => normalizeServiceName(link.service) === 'boomplay')) {
-        resources = await resolveLegacyBoomplayResources(resources, followRedirect);
+        resources = await expandLegacyBoomplayResources(resources, followRedirect);
     }
     return { releaseId: match.releaseId, matchedUrls: findCanonicallyMatchedLinkUrls(links, resources) };
 }

--- a/src/userscripts/ffm_importer/logic.ts
+++ b/src/userscripts/ffm_importer/logic.ts
@@ -233,9 +233,9 @@ function isLegacyBoomplayAlbumUrl(rawUrl: string): boolean {
     }
 }
 
-/** Follow legacy numeric Boomplay album URLs to their current opaque identifiers. */
-export async function resolveLegacyBoomplayResources(resources: string[], resolveUrl: (url: string) => Promise<string>): Promise<string[]> {
-    return Promise.all(
+/** Add the current destinations of legacy numeric Boomplay album URLs as comparison aliases. */
+export async function expandLegacyBoomplayResources(resources: string[], resolveUrl: (url: string) => Promise<string>): Promise<string[]> {
+    const aliases = await Promise.all(
         resources.map(async resource => {
             if (!isLegacyBoomplayAlbumUrl(resource)) return resource;
             try {
@@ -245,6 +245,7 @@ export async function resolveLegacyBoomplayResources(resources: string[], resolv
             }
         }),
     );
+    return [...new Set([...resources, ...aliases])];
 }
 
 /** Return every resolved provider link that is not linked to the matched release. */

--- a/tests/ffm_importer/logic.test.ts
+++ b/tests/ffm_importer/logic.test.ts
@@ -4,6 +4,7 @@ import {
     chooseHarmonyLink,
     canonicalServiceUrlKey,
     decodeFfmDestination,
+    expandLegacyBoomplayResources,
     extractReleaseUrlResources,
     findCanonicallyMatchedLinkUrls,
     findMissingLinks,
@@ -11,7 +12,6 @@ import {
     isIgnoredService,
     normalizeServiceUrl,
     relationshipTypeFor,
-    resolveLegacyBoomplayResources,
     URL_RELATIONSHIP_TYPES,
     type ServiceLink,
 } from '../../src/userscripts/ffm_importer/logic';
@@ -64,12 +64,13 @@ describe('FFM importer logic', () => {
         const legacyUrl = 'https://www.boomplay.com/albums/134155234';
         const currentUrl = 'https://www.boomplay.com/albums/EQUABbK_Gy8KOODzT4ow4hGX';
         const unrelatedUrl = 'https://open.spotify.com/album/example';
-        const resources = await resolveLegacyBoomplayResources([legacyUrl, unrelatedUrl], url => {
+        const resources = await expandLegacyBoomplayResources([legacyUrl, unrelatedUrl], url => {
             expect(url).toBe(legacyUrl);
             return Promise.resolve(currentUrl);
         });
 
-        expect(resources).toEqual([currentUrl, unrelatedUrl]);
+        expect(resources).toEqual([legacyUrl, unrelatedUrl, currentUrl]);
+        expect(findCanonicallyMatchedLinkUrls([serviceLink('boomplay', legacyUrl)], resources)).toEqual([legacyUrl]);
         expect(findCanonicallyMatchedLinkUrls([serviceLink('boomplay', `${currentUrl}?ffm=tracking`)], resources)).toEqual([
             `${currentUrl}?ffm=tracking`,
         ]);


### PR DESCRIPTION
- preserve legacy numeric Boomplay URLs while adding their redirected opaque aliases, allowing either format to match existing MusicBrainz relationships.