### PR TITLE
chore: fully migrate from @include to @match

### DIFF
--- a/bandcamp_importer.user.js
+++ b/bandcamp_importer.user.js
@@ -1,17 +1,11 @@
 // ==UserScript==
 // @name         Import Bandcamp releases to MusicBrainz
 // @description  Add a button on Bandcamp's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2026.7.20.1
+// @version      2026.8.23.1
 // @namespace    http://userscripts.org/users/22504
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/bandcamp_importer.user.js
-// @include      /^https:\/\/[^/]+\/(?:(?:(?:album|track))\/[^/]+|music)$/
-// @include      /^https:\/\/([^.]+)\.bandcamp\.com((?:\/(?:(?:album|track))\/[^/]+|\/|\/music)?)$/
 // @match        https://*.bandcamp.com/*
-// @match        https://bandcamp.com/discover*
-// @include      /^https:\/\/bandcamp\.com\/private\//
-// @include      /^https:\/\/([^.]+)\.bandcamp\.com\/private\//
-// @include      /^https?:\/\/web\.archive\.org\/web\/\d+\/https?:\/\/[^/]+(?:\/(?:album|track)\/[^/]+\/?|\/music\/?|\/?)$/
 // @match        https://web.archive.org/web/*
 // @require      lib/mbimport.js?version=v2026.05.30.1
 // @require      lib/logger.js

--- a/metalarchives_importer.user.js
+++ b/metalarchives_importer.user.js
@@ -1,11 +1,11 @@
 // ==UserScript==
 // @name         Import Metal Archives releases into MusicBrainz
 // @namespace    https://github.com/murdos/musicbrainz-userscripts/
-// @version      2018.2.18.1
+// @version      2026.8.23.1
 // @description  Add a button on Metal Archives release pages allowing to open MusicBrainz release editor with pre-filled data for the selected release
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/metalarchives_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/metalarchives_importer.user.js
-// @include      http*://www.metal-archives.com/albums/*/*/*
+// @match        https://www.metal-archives.com/albums/*/*/*
 // @require      https://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.js
 // @require      lib/mbimport.js
 // @require      lib/mbimportstyle.js

--- a/naxos_library3_importer.user.js
+++ b/naxos_library3_importer.user.js
@@ -2,15 +2,15 @@
 // @name         Import Naxos Music Library 3 releases to MusicBrainz
 // @namespace    https://github.com/murdos/musicbrainz-userscripts
 // @author       loujine
-// @version      2020.9.12
+// @version      2026.8.23.1
 // @downloadURL  https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/naxos_library3_importer.user.js
 // @updateURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/naxos_library3_importer.user.js
 // @icon         https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png
 // @description  Add a button to import Naxos Music Library 3 releases to MusicBrainz
 // @compatible   firefox+tampermonkey
 // @license      MIT
-// @include      http*://*nml3.naxosmusiclibrary.com/catalogue/*
-// @exclude      http*://*nml3.naxosmusiclibrary.com/catalogue/search
+// @match        https://*.nml3.naxosmusiclibrary.com/catalogue/*
+// @exclude      https://*.nml3.naxosmusiclibrary.com/catalogue/search
 // @require      lib/mbimport.js
 // @require      lib/mbimportstyle.js
 // @grant        none

--- a/naxos_library_importer.user.js
+++ b/naxos_library_importer.user.js
@@ -2,14 +2,14 @@
 // @name         Import Naxos Music Library releases to MusicBrainz
 // @namespace    https://github.com/murdos/musicbrainz-userscripts
 // @author       loujine
-// @version      2020.9.12
+// @version      2026.8.23.1
 // @downloadURL  https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/naxos_library_importer.user.js
 // @updateURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/naxos_library_importer.user.js
 // @icon         https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/assets/images/Musicbrainz_import_logo.png
 // @description  Add a button to import Naxos Music Library releases to MusicBrainz
 // @compatible   firefox+tampermonkey
 // @license      MIT
-// @include      http*://*naxosmusiclibrary.com/catalogue/item.asp*
+// @match        https://*.naxosmusiclibrary.com/catalogue/item.asp*
 // @require      lib/mbimport.js
 // @require      lib/mbimportstyle.js
 // @grant        none

--- a/qobuz_importer.user.js
+++ b/qobuz_importer.user.js
@@ -1,11 +1,13 @@
 // ==UserScript==
 // @name         Import Qobuz releases to MusicBrainz
 // @description  Add a button on Qobuz's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2026.07.19.1
+// @version      2026.8.23.1
 // @namespace    https://github.com/murdos/musicbrainz-userscripts
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/qobuz_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/qobuz_importer.user.js
-// @include      /^https?://www\.qobuz\.com/[^/]+/(album|interpreter|label)(/[^/?]+)+(\?.*)?$/
+// @match        https://www.qobuz.com/*/album/*
+// @match        https://www.qobuz.com/*/interpreter/*
+// @match        https://www.qobuz.com/*/label/*
 // @require      https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js
 // @require      lib/mbimport.js?version=v2026.05.30.1
 // @require      lib/logger.js

--- a/set-recording-comments.user.js
+++ b/set-recording-comments.user.js
@@ -1,13 +1,14 @@
 // ==UserScript==
 // @name         MusicBrainz: Set recording comments for a release
 // @description  Batch set recording comments from a Release page.
-// @version      2026.5.31
+// @version      2026.8.23.1
 // @author       Michael Wiencek
 // @license      X11
 // @namespace    790382e7-8714-47a7-bfbd-528d0caa2333
 // @downloadURL  https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/set-recording-comments.user.js
 // @updateURL    https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/master/set-recording-comments.user.js
-// @include      /^https?:\/\/(\w+\.)?musicbrainz\.(org|eu)\/release\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}(\/disc\/\d+|(\?.+?)?$)/
+// @match        https://*.musicbrainz.org/release/*
+// @match        https://*.musicbrainz.eu/release/*
 // @grant        none
 // @run-at       document-idle
 // ==/UserScript==
@@ -39,7 +40,12 @@
 // authorization.
 // ==/License==
 
-setTimeout(setRecordingComments, 1000);
+const SUPPORTED_URL_REGEX =
+    /^https:\/\/(\w+\.)?musicbrainz\.(org|eu)\/release\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}(\/disc\/\d+|(\?.+?)?$)/;
+
+if (SUPPORTED_URL_REGEX.test(location.href)) {
+    setTimeout(setRecordingComments, 1000);
+}
 
 // Keep this intermediate function in case we need to recall it on mb-hydration events, one day
 function setRecordingComments() {


### PR DESCRIPTION
- Closes #685, Closes #981
- custom domains support for bandcamp was dropped, since it's barely used now (all of the white-labeled pages I found were redirects to the base bandcamp.com URL) and enabling it will basically entail running the script pretty much on any website, which is undesired.