### PR TITLE
fix: time converter function incorrectly returns NaN for colon-separated strings

### DIFF
--- a/src/lib/shared/time-functions.ts
+++ b/src/lib/shared/time-functions.ts
@@ -1,6 +1,6 @@
 // convert HH:MM:SS or MM:SS to milliseconds
-export function hmsToMilliSeconds(str: number | string | undefined): number {
-    if (typeof str == 'undefined' || str === '' || isNaN(Number(str))) return NaN;
+export function hmsToMilliSeconds(str: number | string | null | undefined): number {
+    if (typeof str == 'undefined' || str === null || str === '') return NaN;
     if (typeof str == 'number') return str;
     const t = str.split(':');
     let s = 0;

--- a/tests/shared/time-functions.test.ts
+++ b/tests/shared/time-functions.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { hmsToMilliSeconds } from '../../src/lib/shared/time-functions';
+
+describe('hmsToMilliSeconds', () => {
+    it('converts MM:SS durations to milliseconds', () => {
+        expect(hmsToMilliSeconds('06:50')).toBe(410_000);
+    });
+
+    it('converts HH:MM:SS durations to milliseconds', () => {
+        expect(hmsToMilliSeconds('1:02:03')).toBe(3_723_000);
+    });
+
+    it('keeps numeric millisecond durations unchanged', () => {
+        expect(hmsToMilliSeconds(410_000)).toBe(410_000);
+    });
+
+    it('returns NaN for missing or empty durations', () => {
+        expect(hmsToMilliSeconds(undefined)).toBeNaN();
+        expect(hmsToMilliSeconds(null)).toBeNaN();
+        expect(hmsToMilliSeconds('')).toBeNaN();
+        expect(hmsToMilliSeconds(NaN)).toBeNaN();
+        expect(hmsToMilliSeconds('NaN')).toBeNaN();
+        expect(hmsToMilliSeconds('random text')).toBeNaN();
+    });
+});


### PR DESCRIPTION
- e.g. `hmsToMilliSeconds('06:50')` currently returns NaN. This bug was introduced during typescript migration.