### PR TITLE
feat(qobuz_importer): locale-independent Qobuz entity lookup in MB with regex queries

### DIFF
--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -25,48 +25,63 @@ const MBLinks = function (user_cache_key, version, expiration) {
      * @private
      * @param {Object} options - Options for processing the URL match.
      * @param {MBLinks} options.mblinks - The MBLinks instance (for cache and link creation).
-     * @param {Array<{url: string, mb_type: string, insert_func: Function, key?: string}>} options.batch - Batch of URL data entries for this request.
+     * @param {Array<{url: string, mb_type: string, insert_func: Function, key?: string, url_regex?: string}>} options.batch - Batch of URL data entries for this request.
      * @param {string} options.resource - The resource URL from the API response.
      * @param {Array<Object>} [options.relations] - Relations array from the API response.
      */
     function processUrlMatch({ mblinks, batch, resource, relations }) {
-        const matching_urls_data = batch.filter(u => u.url === resource);
+        const matching_urls_data = batch.filter(query => {
+            if (!query.url_regex) return query.url === resource;
+            try {
+                return new RegExp(`^(?:${query.url_regex})$`).test(resource);
+            } catch {
+                return false;
+            }
+        });
         if (matching_urls_data.length === 0) return;
-
-        const reference = matching_urls_data[0];
-        const key = reference.key || reference.url;
-        const _type = reference.mb_type.replace('-', '_');
-
-        if (!mblinks.cache[key]) {
-            mblinks.cache[key] = {
-                timestamp: new Date().getTime(),
-                urls: [],
-            };
-        }
 
         if (!relations) return;
 
-        // Build map of mb_url -> ended (true only if every relation for that URL+entity is ended).
-        const urlData = {};
-        relations.forEach(relation => {
-            if (_type in relation) {
-                const mb_url = `${mblinks.mb_server}/${reference.mb_type}/${relation[_type].id}`;
-                if (!(mb_url in urlData)) urlData[mb_url] = { ended: true };
-                if (!relation.ended) urlData[mb_url].ended = false;
-            }
-        });
+        matching_urls_data.forEach(reference => {
+            const key = reference.key || reference.url;
+            const _type = reference.mb_type.replace('-', '_');
 
-        const cacheUrls = mblinks.cache[key].urls;
-        const getUrl = entry => (typeof entry === 'string' ? entry : entry.url);
-        Object.keys(urlData).forEach(mb_url => {
-            const ended = urlData[mb_url].ended;
-            const alreadyCached = cacheUrls.some(e => getUrl(e) === mb_url);
-            if (!alreadyCached) {
-                cacheUrls.push({ url: mb_url, ended: _type === 'release' ? ended : false });
+            if (!mblinks.cache[key]) {
+                mblinks.cache[key] = {
+                    timestamp: new Date().getTime(),
+                    urls: [],
+                };
             }
-            const link = mblinks.createMusicBrainzLink(mb_url, _type, _type === 'release' ? { ended } : {});
-            matching_urls_data.forEach(m => m.insert_func(link));
+
+            // Build map of mb_url -> ended (true only if every relation for that URL+entity is ended).
+            const urlData = {};
+            relations.forEach(relation => {
+                if (_type in relation) {
+                    const mb_url = `${mblinks.mb_server}/${reference.mb_type}/${relation[_type].id}`;
+                    if (!(mb_url in urlData)) urlData[mb_url] = { ended: true };
+                    if (!relation.ended) urlData[mb_url].ended = false;
+                }
+            });
+
+            const cacheUrls = mblinks.cache[key].urls;
+            const getUrl = entry => (typeof entry === 'string' ? entry : entry.url);
+            Object.keys(urlData).forEach(mb_url => {
+                const ended = urlData[mb_url].ended;
+                const alreadyCached = cacheUrls.some(e => getUrl(e) === mb_url);
+                if (!alreadyCached) {
+                    cacheUrls.push({ url: mb_url, ended: _type === 'release' ? ended : false });
+                }
+                const link = mblinks.createMusicBrainzLink(mb_url, _type, _type === 'release' ? { ended } : {});
+                reference.insert_func(link);
+            });
         });
+    }
+
+    function searchRelations(url) {
+        if (url.relations) return url.relations;
+        const relationLists = url['relation-list'];
+        if (!relationLists) return undefined;
+        return relationLists.flatMap(relationList => relationList.relations || []);
     }
 
     this.supports_local_storage = (function () {
@@ -442,6 +457,74 @@ const MBLinks = function (user_cache_key, version, expiration) {
                 },
             );
         }
+    };
+
+    /**
+     * Search MusicBrainz's indexed URL field with Lucene regular expressions.
+     * @param {Array<{url: string, url_regex: string, mb_type: string, insert_func: Function, key?: string}>} urls_data
+     */
+    this.searchAndDisplayMbLinksByRegex = function (urls_data) {
+        const mblinks = this;
+        const uncachedQueries = [];
+
+        urls_data.forEach(data => {
+            const key = data.key || data.url;
+            if (this.is_cached(key)) {
+                const dataType = data.mb_type.replace('-', '_');
+                mblinks.cache[key].urls.forEach(cacheEntry => {
+                    const mbUrl = typeof cacheEntry === 'string' ? cacheEntry : cacheEntry.url;
+                    const ended = typeof cacheEntry === 'string' ? false : cacheEntry.ended;
+                    data.insert_func(mblinks.createMusicBrainzLink(mbUrl, dataType, dataType === 'release' ? { ended } : {}));
+                });
+            } else if (data.url_regex) {
+                uncachedQueries.push(data);
+            }
+        });
+
+        const batchSize = 20;
+        for (let i = 0; i < uncachedQueries.length; i += batchSize) {
+            const batch = uncachedQueries.slice(i, i + batchSize);
+            const regex = batch.map(data => `(${data.url_regex})`).join('|');
+            this.enqueueRegexSearchPage(batch, regex, 0);
+        }
+    };
+
+    this.enqueueRegexSearchPage = function (batch, regex, offset) {
+        const mblinks = this;
+        const search = `url:/(${regex})/`;
+        const query = `${mblinks.mb_server}/ws/2/url?query=${encodeURIComponent(search)}&fmt=json&limit=100&offset=${offset}`;
+        let handlers = [];
+        if (query in mblinks.ajax_requests) handlers = mblinks.ajax_requests[query].context.handlers;
+
+        handlers.push(function (data) {
+            const urls = data.urls || [];
+            urls.forEach(urlData => {
+                processUrlMatch({
+                    mblinks,
+                    batch,
+                    resource: urlData.resource,
+                    relations: searchRelations(urlData),
+                });
+            });
+            mblinks.saveCache();
+
+            const responseOffset = data.offset || offset;
+            const nextOffset = responseOffset + urls.length;
+            if (typeof data.count === 'number' && urls.length > 0 && nextOffset < data.count) {
+                mblinks.enqueueRegexSearchPage(batch, regex, nextOffset);
+            }
+        });
+
+        mblinks.ajax_requests.push(
+            query,
+            function () {
+                const ctx = this;
+                ctx.mblinks.getJSONWithRetry(ctx.query, function (data) {
+                    ctx.handlers.forEach(handler => handler(data));
+                });
+            },
+            { handlers: handlers, query: query, mblinks: mblinks },
+        );
     };
 
     this.initCache();

--- a/qobuz_importer.user.js
+++ b/qobuz_importer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Qobuz releases to MusicBrainz
 // @description  Add a button on Qobuz's album pages to open MusicBrainz release editor with pre-filled data for the selected release
-// @version      2026.8.30.2
+// @version      2026.9.1
 // @namespace    https://github.com/murdos/musicbrainz-userscripts
 // @downloadURL  https://raw.github.com/murdos/musicbrainz-userscripts/master/qobuz_importer.user.js
 // @updateURL    https://raw.github.com/murdos/musicbrainz-userscripts/master/qobuz_importer.user.js
@@ -11,7 +11,7 @@
 // @require      https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js
 // @require      lib/mbimport.js?version=v2026.05.30.1
 // @require      lib/logger.js
-// @require      lib/mblinks.js?version=v2026.05.31.1
+// @require      lib/mblinks.js?version=v2026.09.01.1
 // @require      lib/mbimportstyle.js
 // @icon         https://metabrainz.org/static/img/projects/musicbrainz.svg
 // @run-at       document-start
@@ -29,65 +29,78 @@ if (DEBUG) {
 // list of qobuz artist id which should be mapped to Various Artists
 const various_artists_ids = [26887, 145383, 353325, 183869, 997899, 2225160];
 const various_composers_ids = [573076];
-const OPEN_QOBUZ_BASE = 'https://open.qobuz.com';
-const PLAY_QOBUZ_BASE = 'https://play.qobuz.com';
 
 let is_classical = false; // release detected as classical
 let album_artist_data = {}; // for switching album artists on classical
 
-function getOpenQobuzArtistUrl(artistId) {
-    return `${OPEN_QOBUZ_BASE}/artist/${artistId}`;
-}
-
-function getOpenQobuzAlbumUrl(albumId) {
-    return `${OPEN_QOBUZ_BASE}/album/${albumId}`;
-}
-
-function getPlayQobuzLabelUrl(labelId) {
-    return `${PLAY_QOBUZ_BASE}/label/${labelId}`;
-}
-
-function getPlayQobuzArtistUrl(artistId) {
-    return `${PLAY_QOBUZ_BASE}/artist/${artistId}`;
-}
-
-function getPlayQobuzAlbumUrl(albumId) {
-    return `${PLAY_QOBUZ_BASE}/album/${albumId}`;
+function escapeRegex(value) {
+    return value.replace(/[\\^$.*+?()[\]{}|/]/g, '\\$&');
 }
 
 /**
- * Derive an open.qobuz.com lookup URL from a www.qobuz.com entity URL.
- * Label URLs are not supported on open.qobuz.com.
+ * Extract the stable Qobuz entity ID from any supported www, open, or play URL.
  */
-function getOpenQobuzUrlFromWwwUrl(url) {
-    let match = url.match(/\/interpreter\/[^/]+\/(\d+)\/?(?:\?|#|$)/);
-    if (match) {
-        return getOpenQobuzArtistUrl(match[1]);
+function getQobuzEntityId(url, mb_type) {
+    let parsedUrl;
+    try {
+        parsedUrl = new URL(url);
+    } catch {
+        return null;
     }
-    match = url.match(/\/album\/[^/]+\/([^/?#]+)\/?(?:\?|#|$)/);
-    if (match) {
-        return getOpenQobuzAlbumUrl(match[1]);
+    if (!['www.qobuz.com', 'open.qobuz.com', 'play.qobuz.com'].includes(parsedUrl.hostname)) {
+        return null;
     }
-    return null;
+
+    const path = parsedUrl.pathname;
+    let match;
+    switch (mb_type) {
+        case 'artist':
+            match = path.match(/^\/(?:[a-z]{2}-[a-z]{2}\/)?interpreter\/[^/]+\/(\d+)\/?$/i);
+            if (!match) match = path.match(/^\/artist\/(\d+)\/?$/i);
+            break;
+        case 'release':
+            match = path.match(/^\/(?:[a-z]{2}-[a-z]{2}\/)?album\/[^/]+\/([^/]+)\/?$/i);
+            if (!match) match = path.match(/^\/album\/([^/]+)\/?$/i);
+            break;
+        case 'label':
+            match = path.match(/^\/(?:[a-z]{2}-[a-z]{2}\/)?label\/[^/]+\/download-streaming-albums\/(\d+)\/?$/i);
+            if (!match) match = path.match(/^\/label\/(\d+)\/?$/i);
+            break;
+        default:
+            return null;
+    }
+    return match?.[1] || null;
 }
 
 /**
- * Derive a play.qobuz.com lookup URL from a www.qobuz.com entity URL.
+ * Build a Lucene-compatible regex matching every supported URL for one Qobuz entity.
+ * open and play are part of the same query as all localized and locale-free www URLs.
  */
-function getPlayQobuzUrlFromWwwUrl(url) {
-    let match = url.match(/\/interpreter\/[^/]+\/(\d+)\/?(?:\?|#|$)/);
-    if (match) {
-        return getPlayQobuzArtistUrl(match[1]);
+function getQobuzUrlRegex(entityId, mb_type) {
+    const id = escapeRegex(entityId);
+    switch (mb_type) {
+        case 'artist':
+            return String.raw`https:\/\/((www\.qobuz\.com\/([a-z]{2}-[a-z]{2}\/)?interpreter\/[^\/]+)|((open|play)\.qobuz\.com\/artist))\/${id}\/?`;
+        case 'release':
+            return String.raw`https:\/\/((www\.qobuz\.com\/([a-z]{2}-[a-z]{2}\/)?album\/[^\/]+)|((open|play)\.qobuz\.com\/album))\/${id}\/?`;
+        case 'label':
+            return String.raw`https:\/\/((www\.qobuz\.com\/([a-z]{2}-[a-z]{2}\/)?label\/[^\/]+\/download-streaming-albums)|(play\.qobuz\.com\/label))\/${id}\/?`;
+        default:
+            return null;
     }
-    match = url.match(/\/album\/[^/]+\/([^/?#]+)\/?(?:\?|#|$)/);
-    if (match) {
-        return getPlayQobuzAlbumUrl(match[1]);
-    }
-    match = url.match(/\/label\/[^/]+\/download-streaming-albums\/(\d+)\/?(?:\?|#|$)/);
-    if (match) {
-        return getPlayQobuzLabelUrl(match[1]);
-    }
-    return null;
+}
+
+function createQobuzMbLinkQuery(url, mb_type, insert_func) {
+    const entityId = getQobuzEntityId(url, mb_type);
+    const url_regex = entityId && getQobuzUrlRegex(entityId, mb_type);
+    if (!entityId || !url_regex) return null;
+    return {
+        url,
+        url_regex,
+        mb_type,
+        insert_func,
+        key: `qobuz:${mb_type}:${entityId}`,
+    };
 }
 
 function isVariousArtists(artist) {
@@ -121,8 +134,6 @@ function parseRelease(data) {
 
     release.script = 'Latn';
     release.url = `https://www.qobuz.com${data.relative_url}`; // no lang
-    release.openQobuzUrl = getOpenQobuzAlbumUrl(data.id);
-    release.playQobuzUrl = getPlayQobuzAlbumUrl(data.id);
 
     release.title = data.title;
     if ($.inArray('Classique', data.genres_list) != -1) {
@@ -151,8 +162,6 @@ function parseRelease(data) {
     } else {
         release.artist_credit = MBImport.makeArtistCredits([data.artist.name]);
         release.artist_credit[0].qobuzUrl = `https://www.qobuz.com/${locale}/interpreter/${data.artist.slug}/${data.artist.id}`;
-        release.artist_credit[0].openQobuzUrl = getOpenQobuzArtistUrl(data.artist.id);
-        release.artist_credit[0].playQobuzUrl = getPlayQobuzArtistUrl(data.artist.id);
     }
 
     release.packaging = 'None';
@@ -434,27 +443,15 @@ function lookupReleaseAndDisplayLinks({ release, mblinks }) {
         }
     };
 
-    const releaseLookupUrls = [];
-    if (release.openQobuzUrl) {
-        releaseLookupUrls.push(release.openQobuzUrl);
-    }
-    if (release.playQobuzUrl) {
-        releaseLookupUrls.push(release.playQobuzUrl);
-    }
-    releaseLookupUrls.push(release.url); // locale-independent URL
-    if (window.location.href) {
-        releaseLookupUrls.push(window.location.href.split('?')[0].split('#')[0]); // URL with locale
-    }
-
-    for (const url of [...new Set(releaseLookupUrls)]) {
-        mblinks.searchAndDisplayMbLink(url, 'release', insertReleaseLinkCb);
-    }
+    const query = createQobuzMbLinkQuery(release.url, 'release', insertReleaseLinkCb);
+    if (query) mblinks.searchAndDisplayMbLinksByRegex([query]);
 }
 
 /**
  * Lookup the artists in MB and add the links to the page.
  */
 function lookupArtistAndDisplayLinks({ release, mblinks }) {
+    const queries = [];
     for (const artist of release.artist_credit) {
         let isArtistLinkInserted = false;
 
@@ -471,27 +468,18 @@ function lookupArtistAndDisplayLinks({ release, mblinks }) {
             }
         };
 
-        const artistLookupUrls = [];
-        if (artist.openQobuzUrl) {
-            artistLookupUrls.push(artist.openQobuzUrl);
-        }
-        if (artist.playQobuzUrl) {
-            artistLookupUrls.push(artist.playQobuzUrl);
-        }
-        if (artist.qobuzUrl) {
-            artistLookupUrls.push(artist.qobuzUrl);
-        }
-
-        for (const url of [...new Set(artistLookupUrls)]) {
-            mblinks.searchAndDisplayMbLink(url, 'artist', insertArtistLinkCb);
-        }
+        if (!artist.qobuzUrl) continue;
+        const query = createQobuzMbLinkQuery(artist.qobuzUrl, 'artist', insertArtistLinkCb);
+        if (!query) continue;
+        queries.push(query);
 
         // Try to get artist MBID from cache and add it to release data
-        const artist_mbid = artistLookupUrls.map(url => mblinks.resolveMBID(url)).find(Boolean);
+        const artist_mbid = mblinks.resolveMBID(query.key);
         if (artist_mbid) {
             artist.mbid = artist_mbid;
         }
     }
+    mblinks.searchAndDisplayMbLinksByRegex(queries);
 }
 
 /**
@@ -499,6 +487,7 @@ function lookupArtistAndDisplayLinks({ release, mblinks }) {
  */
 function lookupLabelAndDisplayLinks({ release, mblinks }) {
     const locale = getCurrentLocale();
+    const queries = [];
     let isLabelLinkInserted = false;
     const insertLabelLinkCb = function (link) {
         if (isLabelLinkInserted) {
@@ -512,42 +501,17 @@ function lookupLabelAndDisplayLinks({ release, mblinks }) {
     };
 
     for (const label of release.labels) {
-        const labelLookupUrls = getEntityUrls(label.qobuzUrl, locale);
-        for (const url of labelLookupUrls) {
-            mblinks.searchAndDisplayMbLink(url, 'label', insertLabelLinkCb);
-        }
+        const query = createQobuzMbLinkQuery(label.qobuzUrl, 'label', insertLabelLinkCb);
+        if (!query) continue;
+        queries.push(query);
 
         // Try to get label MBID from cache and add it to release data
-        const label_mbid = labelLookupUrls.map(url => mblinks.resolveMBID(url)).find(Boolean);
+        const label_mbid = mblinks.resolveMBID(query.key);
         if (label_mbid) {
             label.mbid = label_mbid;
         }
     }
-}
-
-/**
- * Return all Qobuz URL variants to use for MB lookups: locale-dependent and
- * locale-independent www.qobuz.com, plus open.qobuz.com and play.qobuz.com
- * where supported.
- */
-function getEntityUrls(url, locale) {
-    const urls = new Set([url]);
-
-    if (locale && url.includes(`/${locale}/`)) {
-        urls.add(url.replace(`/${locale}/`, '/'));
-    }
-
-    const openQobuzUrl = getOpenQobuzUrlFromWwwUrl(url);
-    if (openQobuzUrl) {
-        urls.add(openQobuzUrl);
-    }
-
-    const playQobuzUrl = getPlayQobuzUrlFromWwwUrl(url);
-    if (playQobuzUrl) {
-        urls.add(playQobuzUrl);
-    }
-
-    return [...urls];
+    mblinks.searchAndDisplayMbLinksByRegex(queries);
 }
 
 const MB_SEARCH_MARKS = {
@@ -626,7 +590,15 @@ function insertMbLinkBeforeElements(elements, link) {
     }
 }
 
-function processDiscographyPage({ mblinks, locale }) {
+function collectQobuzEntityLink(entityMap, url, mb_type, element) {
+    const entityId = getQobuzEntityId(url, mb_type);
+    if (!entityId) return;
+    const key = `${mb_type}:${entityId}`;
+    if (!entityMap.has(key)) entityMap.set(key, { url, elements: [] });
+    entityMap.get(key).elements.push(element);
+}
+
+function processDiscographyPage({ mblinks }) {
     MBSearchItStyle();
 
     const items = document.querySelectorAll('.product__item');
@@ -646,78 +618,52 @@ function processDiscographyPage({ mblinks, locale }) {
         const artist_link = container.querySelector('a[href*="interpreter"]');
         if (artist_link && artist_link instanceof HTMLAnchorElement && artist_link.href) {
             const artist_url = artist_link.href.split('?')[0].split('#')[0];
-            const artist_urls = getEntityUrls(artist_url, locale);
-            artist_urls.forEach(url => {
-                if (!artist_urls_map.has(url)) {
-                    artist_urls_map.set(url, []);
-                }
-                artist_urls_map.get(url).push(artist_link);
-            });
+            collectQobuzEntityLink(artist_urls_map, artist_url, 'artist', artist_link);
         }
 
         const label_link = container.querySelector('a[href*="label"]');
         if (label_link && label_link instanceof HTMLAnchorElement && label_link.href) {
             const label_url = label_link.href.split('?')[0].split('#')[0];
-            const label_urls = getEntityUrls(label_url, locale);
-            label_urls.forEach(url => {
-                if (!label_urls_map.has(url)) {
-                    label_urls_map.set(url, []);
-                }
-                label_urls_map.get(url).push(label_link);
-            });
+            collectQobuzEntityLink(label_urls_map, label_url, 'label', label_link);
         }
 
         const album_link = container.querySelector('a[href*="album"]');
         if (album_link && album_link instanceof HTMLAnchorElement && album_link.href) {
             const album_url = album_link.href.split('?')[0].split('#')[0];
-            const album_urls = getEntityUrls(album_url, locale);
-            album_urls.forEach(url => {
-                if (!album_urls_map.has(url)) {
-                    album_urls_map.set(url, []);
-                }
-                album_urls_map.get(url).push(album_link);
-            });
+            collectQobuzEntityLink(album_urls_map, album_url, 'release', album_link);
         }
     }
 
     // Build urls_data array for batch processing
     const elementsWithSearchLink = new Set();
 
-    artist_urls_map.forEach((artist_link_elements, artist_url) => {
+    artist_urls_map.forEach(({ url: artist_url, elements: artist_link_elements }) => {
         for (const element of artist_link_elements) {
             if (!elementsWithSearchLink.has(element)) {
                 elementsWithSearchLink.add(element);
                 insertMbSearchLinkBeforeElement(element, 'artist', element.textContent.trim());
             }
         }
-        artist_urls_data.push({
-            url: artist_url,
-            mb_type: 'artist',
-            insert_func: function (link) {
-                insertMbLinkBeforeElements(artist_link_elements, link);
-            },
-            key: `artist:${artist_url}`,
+        const query = createQobuzMbLinkQuery(artist_url, 'artist', function (link) {
+            insertMbLinkBeforeElements(artist_link_elements, link);
         });
+        if (query) artist_urls_data.push(query);
     });
 
-    label_urls_map.forEach((label_link_elements, label_url) => {
+    label_urls_map.forEach(({ url: label_url, elements: label_link_elements }) => {
         for (const element of label_link_elements) {
             if (!elementsWithSearchLink.has(element)) {
                 elementsWithSearchLink.add(element);
                 insertMbSearchLinkBeforeElement(element, 'label', element.textContent.trim());
             }
         }
-        label_urls_data.push({
-            url: label_url,
-            mb_type: 'label',
-            insert_func: function (link) {
-                insertMbLinkBeforeElements(label_link_elements, link);
-            },
-            key: `label:${label_url}`,
+        const query = createQobuzMbLinkQuery(label_url, 'label', function (link) {
+            insertMbLinkBeforeElements(label_link_elements, link);
         });
+        if (query) label_urls_data.push(query);
     });
 
-    album_urls_map.forEach((album_link_elements, album_url) => {
+    album_urls_map.forEach(({ url: album_url, elements: album_link_elements }) => {
         for (const element of album_link_elements) {
             if (!elementsWithSearchLink.has(element)) {
                 elementsWithSearchLink.add(element);
@@ -725,20 +671,16 @@ function processDiscographyPage({ mblinks, locale }) {
                 insertMbSearchLinkBeforeElement(element, 'release', albumName);
             }
         }
-        album_urls_data.push({
-            url: album_url,
-            mb_type: 'release',
-            insert_func: function (link) {
-                insertMbLinkBeforeElements(album_link_elements, link);
-            },
-            key: `release:${album_url}`,
+        const query = createQobuzMbLinkQuery(album_url, 'release', function (link) {
+            insertMbLinkBeforeElements(album_link_elements, link);
         });
+        if (query) album_urls_data.push(query);
     });
 
     // Batch retrieve and display links
-    mblinks.searchAndDisplayMbLinks(artist_urls_data);
-    mblinks.searchAndDisplayMbLinks(label_urls_data);
-    mblinks.searchAndDisplayMbLinks(album_urls_data);
+    mblinks.searchAndDisplayMbLinksByRegex(artist_urls_data);
+    mblinks.searchAndDisplayMbLinksByRegex(label_urls_data);
+    mblinks.searchAndDisplayMbLinksByRegex(album_urls_data);
 }
 
 function processReleasePage({ mblinks }) {
@@ -784,7 +726,6 @@ $(document).ready(function () {
     const mblinks = new MBLinks('QOBUZ_MBLINKS_CACHE');
     const pageTypeRegex = new RegExp(`^\\/([a-z]{2}-[a-z]{2})?(?:\\/)?(interpreter|album|label)\\/`);
 
-    const locale = window.location.pathname.match(pageTypeRegex)?.[1];
     const pageType = window.location.pathname.match(pageTypeRegex)?.[2];
 
     if (!pageType) {
@@ -792,13 +733,13 @@ $(document).ready(function () {
     } else {
         switch (pageType) {
             case 'interpreter':
-                processDiscographyPage({ mblinks, locale });
+                processDiscographyPage({ mblinks });
                 break;
             case 'album':
                 processReleasePage({ mblinks });
                 break;
             case 'label':
-                processDiscographyPage({ mblinks, locale });
+                processDiscographyPage({ mblinks });
                 break;
             default:
                 return;

--- a/src/lib/mblinks.ts
+++ b/src/lib/mblinks.ts
@@ -17,6 +17,8 @@ export interface MBLinkQuery {
     mb_type: string;
     insert_func: (link: string) => void;
     key?: string;
+    /** Lucene-compatible regular expression used to match URL search results. */
+    url_regex?: string;
 }
 
 interface CacheUrl {
@@ -37,10 +39,13 @@ interface Relation {
 interface UrlResponse {
     resource: string;
     relations?: Relation[];
+    'relation-list'?: { relations?: Relation[] }[];
 }
 
 interface BatchResponse extends Partial<UrlResponse> {
     urls?: UrlResponse[];
+    count?: number;
+    offset?: number;
 }
 
 interface LinkInfo {
@@ -130,46 +135,59 @@ function processUrlMatch({
     resource: string;
     relations: Relation[] | undefined;
 }): void {
-    const matching_urls_data = batch.filter(u => u.url === resource);
+    const matching_urls_data = batch.filter(query => {
+        if (!query.url_regex) return query.url === resource;
+        try {
+            return new RegExp(`^(?:${query.url_regex})$`).test(resource);
+        } catch {
+            return false;
+        }
+    });
     if (matching_urls_data.length === 0) return;
-
-    const reference = matching_urls_data[0]!;
-    const key = reference.key || reference.url;
-    const _type = reference.mb_type.replace('-', '_');
-
-    if (!mblinks.cache[key]) {
-        mblinks.cache[key] = {
-            timestamp: new Date().getTime(),
-            urls: [],
-        };
-    }
 
     if (!relations) return;
 
-    // Build map of mb_url -> ended (true only if every relation for that URL+entity is ended).
-    const urlData: Record<string, { ended: boolean }> = {};
-    relations.forEach(relation => {
-        if (_type in relation) {
-            const entity = relation[_type] as { id: string };
-            const mb_url = `${mblinks.mb_server}/${reference.mb_type}/${entity.id}`;
-            if (!(mb_url in urlData)) urlData[mb_url] = { ended: true };
-            if (!relation.ended) urlData[mb_url]!.ended = false;
-        }
-    });
+    matching_urls_data.forEach(reference => {
+        const key = reference.key || reference.url;
+        const _type = reference.mb_type.replace('-', '_');
 
-    const cacheUrls = mblinks.cache[key].urls!;
-    const getUrl = (entry: string | CacheUrl) => (typeof entry === 'string' ? entry : entry.url);
-    Object.keys(urlData).forEach(mb_url => {
-        const ended = urlData[mb_url]!.ended;
-        const alreadyCached = cacheUrls.some(e => getUrl(e) === mb_url);
-        if (!alreadyCached) {
-            cacheUrls.push({ url: mb_url, ended: _type === 'release' ? ended : false });
+        if (!mblinks.cache[key]) {
+            mblinks.cache[key] = {
+                timestamp: new Date().getTime(),
+                urls: [],
+            };
         }
-        const link = mblinks.createMusicBrainzLink(mb_url, _type, _type === 'release' ? { ended } : {});
-        matching_urls_data.forEach(m => {
-            m.insert_func(link);
+
+        // Build map of mb_url -> ended (true only if every relation for that URL+entity is ended).
+        const urlData: Record<string, { ended: boolean }> = {};
+        relations.forEach(relation => {
+            if (_type in relation) {
+                const entity = relation[_type] as { id: string };
+                const mb_url = `${mblinks.mb_server}/${reference.mb_type}/${entity.id}`;
+                if (!(mb_url in urlData)) urlData[mb_url] = { ended: true };
+                if (!relation.ended) urlData[mb_url]!.ended = false;
+            }
+        });
+
+        const cacheUrls = mblinks.cache[key].urls!;
+        const getUrl = (entry: string | CacheUrl) => (typeof entry === 'string' ? entry : entry.url);
+        Object.keys(urlData).forEach(mb_url => {
+            const ended = urlData[mb_url]!.ended;
+            const alreadyCached = cacheUrls.some(e => getUrl(e) === mb_url);
+            if (!alreadyCached) {
+                cacheUrls.push({ url: mb_url, ended: _type === 'release' ? ended : false });
+            }
+            const link = mblinks.createMusicBrainzLink(mb_url, _type, _type === 'release' ? { ended } : {});
+            reference.insert_func(link);
         });
     });
+}
+
+function searchRelations(url: UrlResponse): Relation[] | undefined {
+    if (url.relations) return url.relations;
+    const relationLists = url['relation-list'];
+    if (!relationLists) return undefined;
+    return relationLists.flatMap(relationList => relationList.relations ?? []);
 }
 
 // user_cache_key = textual key used to store cached data in local storage
@@ -447,6 +465,79 @@ export class MBLinks {
                 },
             );
         }
+    }
+
+    /**
+     * Search MusicBrainz's indexed URL field with Lucene regular expressions.
+     */
+    searchAndDisplayMbLinksByRegex(urls_data: MBLinkQuery[]): void {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias -- Kept in line with the callback contexts above.
+        const mblinks = this;
+        const uncachedQueries: MBLinkQuery[] = [];
+
+        urls_data.forEach(data => {
+            const key = data.key || data.url;
+            if (this.is_cached(key)) {
+                const dataType = data.mb_type.replace('-', '_');
+                mblinks.cache[key]!.urls!.forEach(cacheEntry => {
+                    const mbUrl = typeof cacheEntry === 'string' ? cacheEntry : cacheEntry.url;
+                    const ended = typeof cacheEntry === 'string' ? false : cacheEntry.ended;
+                    data.insert_func(mblinks.createMusicBrainzLink(mbUrl, dataType, dataType === 'release' ? { ended } : {}));
+                });
+            } else if (data.url_regex) {
+                uncachedQueries.push(data);
+            }
+        });
+
+        const batchSize = 20;
+        for (let i = 0; i < uncachedQueries.length; i += batchSize) {
+            const batch = uncachedQueries.slice(i, i + batchSize);
+            const regex = batch.map(data => `(${data.url_regex})`).join('|');
+            this.enqueueRegexSearchPage(batch, regex, 0);
+        }
+    }
+
+    private enqueueRegexSearchPage(batch: MBLinkQuery[], regex: string, offset: number): void {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias -- Kept in line with the callback contexts above.
+        const mblinks = this;
+        const search = `url:/(${regex})/`;
+        const query = `${mblinks.mb_server}/ws/2/url?query=${encodeURIComponent(search)}&fmt=json&limit=100&offset=${offset}`;
+        let handlers: ((data: BatchResponse) => void)[] = [];
+        const request = mblinks.ajax_requests[query];
+        if (typeof request === 'object') handlers = request.context.handlers;
+
+        handlers.push(function (data) {
+            const urls = data.urls ?? [];
+            urls.forEach(urlData => {
+                processUrlMatch({
+                    mblinks,
+                    batch,
+                    resource: urlData.resource,
+                    relations: searchRelations(urlData),
+                });
+            });
+            mblinks.saveCache();
+
+            const responseOffset = data.offset ?? offset;
+            const nextOffset = responseOffset + urls.length;
+            if (typeof data.count === 'number' && urls.length > 0 && nextOffset < data.count) {
+                mblinks.enqueueRegexSearchPage(batch, regex, nextOffset);
+            }
+        });
+
+        mblinks.ajax_requests.push(
+            query,
+            function () {
+                // eslint-disable-next-line @typescript-eslint/no-this-alias -- Kept in line with the original callback context.
+                const ctx = this;
+                ctx.mblinks.getJSONWithRetry(ctx.query, function (data) {
+                    ctx.handlers.forEach(handler => {
+                        handler(data);
+                    });
+                });
+            },
+            { handlers, query, mblinks },
+        );
     }
 }
 

--- a/tests/qobuz_importer/url-lookups.test.ts
+++ b/tests/qobuz_importer/url-lookups.test.ts
@@ -1,0 +1,160 @@
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MBLinks } from '../../src/lib/mblinks';
+
+type QobuzHelpers = {
+    getQobuzEntityId: (url: string, mbType: string) => string | null;
+    getQobuzUrlRegex: (entityId: string, mbType: string) => string | null;
+};
+
+function loadQobuzHelpers(): QobuzHelpers {
+    const source = fs.readFileSync(new URL('../../qobuz_importer.user.js', import.meta.url), 'utf8');
+    const jquery = Object.assign(
+        () => ({
+            on() {},
+            ready() {},
+        }),
+        {
+            noConflict: () => jquery,
+        },
+    );
+    const context = {
+        URL,
+        document: {},
+        jQuery: jquery,
+    };
+    vm.runInNewContext(`${source}\nglobalThis.qobuzHelpers = { getQobuzEntityId, getQobuzUrlRegex };`, context);
+    return (context as typeof context & { qobuzHelpers: QobuzHelpers }).qobuzHelpers;
+}
+
+const helpers = loadQobuzHelpers();
+
+describe('Qobuz URL lookup regexes', () => {
+    it.each([
+        ['https://www.qobuz.com/nl-nl/interpreter/marcu-rares/8365719', 'artist', '8365719'],
+        ['https://www.qobuz.com/interpreter/marcu-rares/8365719', 'artist', '8365719'],
+        ['https://open.qobuz.com/artist/8365719', 'artist', '8365719'],
+        ['https://play.qobuz.com/artist/8365719', 'artist', '8365719'],
+        ['https://www.qobuz.com/us-en/album/salvaging-the-future-dean-de-benedictis/ki3mxj3oly9vd', 'release', 'ki3mxj3oly9vd'],
+        ['https://www.qobuz.com/album/salvaging-the-future-dean-de-benedictis/ki3mxj3oly9vd', 'release', 'ki3mxj3oly9vd'],
+        ['https://open.qobuz.com/album/ki3mxj3oly9vd', 'release', 'ki3mxj3oly9vd'],
+        ['https://play.qobuz.com/album/ki3mxj3oly9vd', 'release', 'ki3mxj3oly9vd'],
+        ['https://www.qobuz.com/nl-nl/label/london-records-because-ltd/download-streaming-albums/4899837', 'label', '4899837'],
+        ['https://www.qobuz.com/label/london-records-because-ltd/download-streaming-albums/4899837', 'label', '4899837'],
+        ['https://play.qobuz.com/label/4899837', 'label', '4899837'],
+    ])('extracts %s', (url, mbType, expectedId) => {
+        expect(helpers.getQobuzEntityId(url, mbType)).toBe(expectedId);
+    });
+
+    it.each([
+        [
+            'artist',
+            '8365719',
+            [
+                'https://www.qobuz.com/nl-nl/interpreter/marcu-rares/8365719',
+                'https://www.qobuz.com/interpreter/marcu-rares/8365719',
+                'https://open.qobuz.com/artist/8365719',
+                'https://play.qobuz.com/artist/8365719',
+            ],
+        ],
+        [
+            'release',
+            'ki3mxj3oly9vd',
+            [
+                'https://www.qobuz.com/us-en/album/salvaging-the-future-dean-de-benedictis/ki3mxj3oly9vd',
+                'https://www.qobuz.com/album/salvaging-the-future-dean-de-benedictis/ki3mxj3oly9vd',
+                'https://open.qobuz.com/album/ki3mxj3oly9vd',
+                'https://play.qobuz.com/album/ki3mxj3oly9vd',
+            ],
+        ],
+        [
+            'label',
+            '4899837',
+            [
+                'https://www.qobuz.com/nl-nl/label/london-records-because-ltd/download-streaming-albums/4899837',
+                'https://www.qobuz.com/label/london-records-because-ltd/download-streaming-albums/4899837',
+                'https://play.qobuz.com/label/4899837',
+            ],
+        ],
+    ])('matches all %s lookup forms in one expression', (mbType, id, urls) => {
+        const source = helpers.getQobuzUrlRegex(id, mbType);
+        expect(source).not.toBeNull();
+        const regex = new RegExp(`^(?:${source})$`);
+        urls.forEach(url => {
+            expect(regex.test(url)).toBe(true);
+        });
+        expect(regex.test(`https://playqobuz.com/${mbType}/${id}`)).toBe(false);
+    });
+});
+
+describe('MBLinks regex URL search', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.stubGlobal('localStorage', {
+            getItem: vi.fn(() => null),
+            key: vi.fn(() => null),
+            length: 0,
+            removeItem: vi.fn(),
+            setItem: vi.fn(),
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllTimers();
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    it('maps relation-list search results back to the logical cache key', async () => {
+        const requestedUrls: string[] = [];
+        const fetchMock = vi.fn((input: string) => {
+            requestedUrls.push(input);
+            return Promise.resolve({
+                ok: true,
+                json: () =>
+                    Promise.resolve({
+                        count: 1,
+                        offset: 0,
+                        urls: [
+                            {
+                                resource: 'https://play.qobuz.com/artist/8365719',
+                                'relation-list': [
+                                    {
+                                        relations: [
+                                            {
+                                                artist: { id: '12345678-1234-1234-1234-123456789abc' },
+                                                ended: false,
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    }),
+            });
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        const insert = vi.fn();
+        const mblinks = new MBLinks('QOBUZ_TEST');
+        const urlRegex = helpers.getQobuzUrlRegex('8365719', 'artist');
+
+        mblinks.searchAndDisplayMbLinksByRegex([
+            {
+                url: 'https://www.qobuz.com/interpreter/marcu-rares/8365719',
+                url_regex: urlRegex!,
+                mb_type: 'artist',
+                insert_func: insert,
+                key: 'qobuz:artist:8365719',
+            },
+        ]);
+        await vi.advanceTimersByTimeAsync(1000);
+
+        expect(fetchMock).toHaveBeenCalledOnce();
+        expect(decodeURIComponent(requestedUrls[0]!)).toContain('query=url:/');
+        expect(insert).toHaveBeenCalledWith(expect.stringContaining('/artist/12345678-1234-1234-1234-123456789abc'));
+        expect(mblinks.resolveMBID('qobuz:artist:8365719')).toBe('12345678-1234-1234-1234-123456789abc');
+    });
+});


### PR DESCRIPTION
- use MusicBrainz indexed URL searches to match Qobuz entities by their stable IDs instead of querying individual locale-dependent URLs.
- match localized and locale-free www.qobuz.com URLs together with their open.qobuz.com and play.qobuz.com equivalents in a single request.
- adds reusable regex lookup support to MBLinks, including batching, pagination, relation-list response handling, and logical entity caching. Add tests covering artist, release, and label URL forms.