### PR TITLE
fix(mblinks): rate-limit retries with other API requests

### DIFF
--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -125,6 +125,7 @@ const MBLinks = function (user_cache_key, version, expiration) {
             return handler.bind(context);
         },
     };
+    let nextRequestAt = 0;
     this.cache = {};
     this.expirationMinutes = typeof expiration != 'undefined' && expiration !== false ? parseInt(expiration, 10) : 90 * 24 * 60; // default to 90 days
     let cache_version = 3;
@@ -164,7 +165,7 @@ const MBLinks = function (user_cache_key, version, expiration) {
         const retryDelayMs = 2000;
         let attempt = 0;
 
-        function doRequest() {
+        const doRequest = () => {
             attempt += 1;
             fetch(url, { headers: { Accept: 'application/json' } })
                 .then(function (response) {
@@ -181,17 +182,28 @@ const MBLinks = function (user_cache_key, version, expiration) {
                         alwaysCallback();
                     }
                 })
-                .catch(function (error) {
+                .catch(error => {
                     const status = error.status || 0;
                     const is5xx = status >= 500 && status < 600;
                     if (is5xx && attempt <= maxRetries) {
-                        setTimeout(doRequest, retryDelayMs);
+                        setTimeout(() => {
+                            this.scheduleRequest(doRequest);
+                        }, retryDelayMs);
                     } else if (typeof alwaysCallback === 'function') {
                         alwaysCallback();
                     }
                 });
-        }
-        doRequest();
+        };
+        this.scheduleRequest(doRequest);
+    };
+
+    this.scheduleRequest = function (request) {
+        const now = Date.now();
+        const runAt = Math.max(now, nextRequestAt);
+        nextRequestAt = runAt + 1000;
+        const delay = runAt - now;
+        if (delay === 0) request();
+        else setTimeout(request, delay);
     };
 
     this.initCache = function () {

--- a/src/lib/mblinks.ts
+++ b/src/lib/mblinks.ts
@@ -196,6 +196,7 @@ function searchRelations(url: UrlResponse): Relation[] | undefined {
 export class MBLinks {
     supports_local_storage: boolean;
     ajax_requests = new AjaxRequests();
+    private nextRequestAt = 0;
     cache: Record<string, CacheEntry> = {};
     expirationMinutes: number;
     user_cache_key: string;
@@ -253,7 +254,7 @@ export class MBLinks {
         const retryDelayMs = 2000;
         let attempt = 0;
 
-        function doRequest() {
+        const doRequest = () => {
             attempt += 1;
             fetch(url, { headers: { Accept: 'application/json' } })
                 .then(function (response) {
@@ -270,17 +271,28 @@ export class MBLinks {
                         alwaysCallback();
                     }
                 })
-                .catch(function (error: unknown) {
+                .catch((error: unknown) => {
                     const status = isErrorWithStatus(error) ? error.status : 0;
                     const is5xx = status >= 500 && status < 600;
                     if (is5xx && attempt <= maxRetries) {
-                        setTimeout(doRequest, retryDelayMs);
+                        setTimeout(() => {
+                            this.scheduleRequest(doRequest);
+                        }, retryDelayMs);
                     } else if (typeof alwaysCallback === 'function') {
                         alwaysCallback();
                     }
                 });
-        }
-        doRequest();
+        };
+        this.scheduleRequest(doRequest);
+    }
+
+    private scheduleRequest(request: () => void): void {
+        const now = Date.now();
+        const runAt = Math.max(now, this.nextRequestAt);
+        this.nextRequestAt = runAt + 1000;
+        const delay = runAt - now;
+        if (delay === 0) request();
+        else setTimeout(request, delay);
     }
 
     initCache(): void {

--- a/tests/qobuz_importer/url-lookups.test.ts
+++ b/tests/qobuz_importer/url-lookups.test.ts
@@ -157,4 +157,28 @@ describe('MBLinks regex URL search', () => {
         expect(insert).toHaveBeenCalledWith(expect.stringContaining('/artist/12345678-1234-1234-1234-123456789abc'));
         expect(mblinks.resolveMBID('qobuz:artist:8365719')).toBe('12345678-1234-1234-1234-123456789abc');
     });
+
+    it('keeps retries at least one second apart from other requests', async () => {
+        const requestTimes: number[] = [];
+        const fetchMock = vi
+            .fn()
+            .mockImplementationOnce(() => {
+                requestTimes.push(Date.now());
+                return Promise.resolve({ ok: false, status: 503 });
+            })
+            .mockImplementation(() => {
+                requestTimes.push(Date.now());
+                return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+            });
+        vi.stubGlobal('fetch', fetchMock);
+        const mblinks = new MBLinks('QOBUZ_RETRY_TEST');
+
+        mblinks.getJSONWithRetry('first', vi.fn());
+        mblinks.getJSONWithRetry('second', vi.fn());
+        await vi.advanceTimersByTimeAsync(3000);
+
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(requestTimes[1]! - requestTimes[0]!).toBeGreaterThanOrEqual(1000);
+        expect(requestTimes[2]! - requestTimes[1]!).toBeGreaterThanOrEqual(1000);
+    });
 });


### PR DESCRIPTION
- MBLinks already retried MusicBrainz 5xx responses, including 503s, but retries used an independent timer. A retry could therefore overlap with another queued request and violate MusicBrainz's one-request-per-second rate limit.
- Schedule initial requests and retries through the same rate limiter, while retaining the existing retry delay and maximum attempt count.
- Add a regression test covering a 503 retry alongside another request.