### PR TITLE
fix(mblinks): use exponential backoff instead of 1s increments when MB API returns 5XXs

### DIFF
--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -155,14 +155,13 @@ const MBLinks = function (user_cache_key, version, expiration) {
     };
 
     /**
-     * GET JSON with retry on 5xx errors (e.g. 503). Retries up to 3 times with a delay between attempts.
+     * GET JSON with retry on 5xx errors (e.g. 503). Retries up to 3 times with exponential backoff.
      * @param {string} url - The URL to request.
      * @param {function} successCallback - Called with response data on success.
      * @param {function} [alwaysCallback] - Called when the request is finally done (success or after giving up retries).
      */
     this.getJSONWithRetry = function (url, successCallback, alwaysCallback) {
         const maxRetries = 3;
-        const retryDelayMs = 2000;
         let attempt = 0;
 
         const doRequest = () => {
@@ -186,6 +185,7 @@ const MBLinks = function (user_cache_key, version, expiration) {
                     const status = error.status || 0;
                     const is5xx = status >= 500 && status < 600;
                     if (is5xx && attempt <= maxRetries) {
+                        const retryDelayMs = 1000 * 2 ** (attempt - 1);
                         setTimeout(() => {
                             this.scheduleRequest(doRequest);
                         }, retryDelayMs);

--- a/src/lib/mblinks.ts
+++ b/src/lib/mblinks.ts
@@ -244,14 +244,13 @@ export class MBLinks {
     }
 
     /**
-     * GET JSON with retry on 5xx errors (e.g. 503). Retries up to 3 times with a delay between attempts.
+     * GET JSON with retry on 5xx errors (e.g. 503). Retries up to 3 times with exponential backoff.
      * @param url - The URL to request.
      * @param successCallback - Called with response data on success.
      * @param alwaysCallback - Called when the request is finally done (success or after giving up retries).
      */
     getJSONWithRetry(url: string, successCallback: (data: BatchResponse) => void, alwaysCallback?: () => void): void {
         const maxRetries = 3;
-        const retryDelayMs = 2000;
         let attempt = 0;
 
         const doRequest = () => {
@@ -275,6 +274,7 @@ export class MBLinks {
                     const status = isErrorWithStatus(error) ? error.status : 0;
                     const is5xx = status >= 500 && status < 600;
                     if (is5xx && attempt <= maxRetries) {
+                        const retryDelayMs = 1000 * 2 ** (attempt - 1);
                         setTimeout(() => {
                             this.scheduleRequest(doRequest);
                         }, retryDelayMs);

--- a/tests/qobuz_importer/url-lookups.test.ts
+++ b/tests/qobuz_importer/url-lookups.test.ts
@@ -181,4 +181,21 @@ describe('MBLinks regex URL search', () => {
         expect(requestTimes[1]! - requestTimes[0]!).toBeGreaterThanOrEqual(1000);
         expect(requestTimes[2]! - requestTimes[1]!).toBeGreaterThanOrEqual(1000);
     });
+
+    it('uses exponential backoff for repeated 503 responses', async () => {
+        const requestTimes: number[] = [];
+        const fetchMock = vi.fn(() => {
+            requestTimes.push(Date.now());
+            const ok = requestTimes.length === 4;
+            return Promise.resolve({ ok, status: ok ? 200 : 503, json: () => Promise.resolve({}) });
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        const mblinks = new MBLinks('QOBUZ_BACKOFF_TEST');
+
+        mblinks.getJSONWithRetry('request', vi.fn());
+        await vi.advanceTimersByTimeAsync(8000);
+
+        expect(fetchMock).toHaveBeenCalledTimes(4);
+        expect(requestTimes.map((time, index) => (index === 0 ? 0 : time - requestTimes[index - 1]!))).toEqual([0, 1000, 2000, 4000]);
+    });
 });


### PR DESCRIPTION
- retrying every second doesn't seem to be working reliably, MB stills says 'busy'