### PR TITLE
fix(mblinks): increase the retry cap for failed requests from 3 to n requests within 5 minutes

### DIFF
--- a/lib/mblinks.js
+++ b/lib/mblinks.js
@@ -155,13 +155,14 @@ const MBLinks = function (user_cache_key, version, expiration) {
     };
 
     /**
-     * GET JSON with retry on 5xx errors (e.g. 503). Retries up to 3 times with exponential backoff.
+     * GET JSON with retry on 5xx errors (e.g. 503), using exponential backoff capped at 30 seconds
+     * and a five-minute retry budget.
      * @param {string} url - The URL to request.
      * @param {function} successCallback - Called with response data on success.
      * @param {function} [alwaysCallback] - Called when the request is finally done (success or after giving up retries).
      */
     this.getJSONWithRetry = function (url, successCallback, alwaysCallback) {
-        const maxRetries = 3;
+        const retryDeadline = Date.now() + 5 * 60 * 1000;
         let attempt = 0;
 
         const doRequest = () => {
@@ -184,11 +185,15 @@ const MBLinks = function (user_cache_key, version, expiration) {
                 .catch(error => {
                     const status = error.status || 0;
                     const is5xx = status >= 500 && status < 600;
-                    if (is5xx && attempt <= maxRetries) {
-                        const retryDelayMs = 1000 * 2 ** (attempt - 1);
-                        setTimeout(() => {
-                            this.scheduleRequest(doRequest);
-                        }, retryDelayMs);
+                    if (is5xx) {
+                        const retryDelayMs = Math.min(30_000, 1000 * 2 ** (attempt - 1));
+                        if (Date.now() + retryDelayMs <= retryDeadline) {
+                            setTimeout(() => {
+                                this.scheduleRequest(doRequest);
+                            }, retryDelayMs);
+                        } else if (typeof alwaysCallback === 'function') {
+                            alwaysCallback();
+                        }
                     } else if (typeof alwaysCallback === 'function') {
                         alwaysCallback();
                     }

--- a/src/lib/mblinks.ts
+++ b/src/lib/mblinks.ts
@@ -244,13 +244,14 @@ export class MBLinks {
     }
 
     /**
-     * GET JSON with retry on 5xx errors (e.g. 503). Retries up to 3 times with exponential backoff.
+     * GET JSON with retry on 5xx errors (e.g. 503), using exponential backoff capped at 30 seconds
+     * and a five-minute retry budget.
      * @param url - The URL to request.
      * @param successCallback - Called with response data on success.
      * @param alwaysCallback - Called when the request is finally done (success or after giving up retries).
      */
     getJSONWithRetry(url: string, successCallback: (data: BatchResponse) => void, alwaysCallback?: () => void): void {
-        const maxRetries = 3;
+        const retryDeadline = Date.now() + 5 * 60 * 1000;
         let attempt = 0;
 
         const doRequest = () => {
@@ -273,11 +274,15 @@ export class MBLinks {
                 .catch((error: unknown) => {
                     const status = isErrorWithStatus(error) ? error.status : 0;
                     const is5xx = status >= 500 && status < 600;
-                    if (is5xx && attempt <= maxRetries) {
-                        const retryDelayMs = 1000 * 2 ** (attempt - 1);
-                        setTimeout(() => {
-                            this.scheduleRequest(doRequest);
-                        }, retryDelayMs);
+                    if (is5xx) {
+                        const retryDelayMs = Math.min(30_000, 1000 * 2 ** (attempt - 1));
+                        if (Date.now() + retryDelayMs <= retryDeadline) {
+                            setTimeout(() => {
+                                this.scheduleRequest(doRequest);
+                            }, retryDelayMs);
+                        } else if (typeof alwaysCallback === 'function') {
+                            alwaysCallback();
+                        }
                     } else if (typeof alwaysCallback === 'function') {
                         alwaysCallback();
                     }

--- a/tests/qobuz_importer/url-lookups.test.ts
+++ b/tests/qobuz_importer/url-lookups.test.ts
@@ -182,20 +182,35 @@ describe('MBLinks regex URL search', () => {
         expect(requestTimes[2]! - requestTimes[1]!).toBeGreaterThanOrEqual(1000);
     });
 
-    it('uses exponential backoff for repeated 503 responses', async () => {
+    it('keeps retrying 503 responses with exponential backoff', async () => {
         const requestTimes: number[] = [];
         const fetchMock = vi.fn(() => {
             requestTimes.push(Date.now());
-            const ok = requestTimes.length === 4;
+            const ok = requestTimes.length === 6;
             return Promise.resolve({ ok, status: ok ? 200 : 503, json: () => Promise.resolve({}) });
         });
         vi.stubGlobal('fetch', fetchMock);
         const mblinks = new MBLinks('QOBUZ_BACKOFF_TEST');
 
         mblinks.getJSONWithRetry('request', vi.fn());
-        await vi.advanceTimersByTimeAsync(8000);
+        await vi.advanceTimersByTimeAsync(32_000);
 
-        expect(fetchMock).toHaveBeenCalledTimes(4);
-        expect(requestTimes.map((time, index) => (index === 0 ? 0 : time - requestTimes[index - 1]!))).toEqual([0, 1000, 2000, 4000]);
+        expect(fetchMock).toHaveBeenCalledTimes(6);
+        expect(requestTimes.map((time, index) => (index === 0 ? 0 : time - requestTimes[index - 1]!))).toEqual([
+            0, 1000, 2000, 4000, 8000, 16_000,
+        ]);
+    });
+
+    it('stops retrying before the five-minute retry budget is exceeded', async () => {
+        const fetchMock = vi.fn(() => Promise.resolve({ ok: false, status: 503 }));
+        const done = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        const mblinks = new MBLinks('QOBUZ_RETRY_BUDGET_TEST');
+
+        mblinks.getJSONWithRetry('request', vi.fn(), done);
+        await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+        expect(fetchMock).toHaveBeenCalledTimes(14);
+        expect(done).toHaveBeenCalledOnce();
     });
 });


### PR DESCRIPTION
- also cap the exponential backoff to 30s, which means it will make roughly 14 attempts within 5 minutes before bailing