### PR TITLE
fix(deezer_importer): Deezer importer script requires a page refresh to work (#699)

### DIFF
--- a/src/userscripts/deezer_importer/index.ts
+++ b/src/userscripts/deezer_importer/index.ts
@@ -1,23 +1,43 @@
 import { Logger, LogLevel } from '~/lib/logger';
 import { MBImport } from '~/lib/mbimport';
 import { MBImportStyle } from '~/lib/mbimportstyle';
+import { subscribeToSPANavigation } from '~/lib/shared/spa-navigation';
 
 import { getDeezerReleaseData } from './utils/getDeezerReleaseData';
 import { parseDeezerRelease } from './utils/parseDeezerRelease';
 
 const LOGGER = new Logger('deezer_importer', LogLevel.INFO);
 
-function waitForEl(selector: string, callback: () => void): void {
-    if (document.querySelector(selector)) {
-        callback();
+let currentRunId = 0;
+let mountedElements: HTMLElement[] = [];
+
+function cleanup(): void {
+    mountedElements.forEach(el => {
+        el.remove();
+    });
+    mountedElements = [];
+}
+
+function waitForEl(selector: string, runId: number, callback: (el: HTMLElement) => void): void {
+    if (runId !== currentRunId) {
+        return;
+    }
+    const el = document.querySelector<HTMLElement>(selector);
+    if (el) {
+        callback(el);
     } else {
         setTimeout(() => {
-            waitForEl(selector, callback);
+            waitForEl(selector, runId, callback);
         }, 100);
     }
 }
 
-function insertLink(release: Parameters<typeof MBImport.buildFormParameters>[0], releaseUrl: string, isrcs: (string | null)[]): void {
+function insertLink(
+    release: Parameters<typeof MBImport.buildFormParameters>[0],
+    releaseUrl: string,
+    isrcs: (string | null)[],
+    runId: number,
+): void {
     const editNote = MBImport.makeEditNote(releaseUrl, 'Deezer');
     const parameters = MBImport.buildFormParameters(release, editNote);
 
@@ -54,49 +74,64 @@ function insertLink(release: Parameters<typeof MBImport.buildFormParameters>[0],
 
     const toolbarItems = [importItem, searchItem, isrcItem];
 
-    waitForEl('[data-testid="toolbar"]', () => {
-        const toolbar = document.querySelector<HTMLElement>('[data-testid="toolbar"]');
-        if (toolbar) {
+    waitForEl('[data-testid="toolbar"]', runId, toolbar => {
+        if (runId === currentRunId) {
             toolbar.style.alignItems = 'center';
             toolbar.append(...toolbarItems);
+            mountedElements.push(...toolbarItems);
         }
     });
 
     // Deezer Mobile is a completely different App, so we need to mount differently
-    waitForEl('[data-tracking-label="main-CTA"]', () => {
-        const cta = document.querySelector<HTMLElement>('[data-tracking-label="main-CTA"]');
-        if (cta) {
+    waitForEl('[data-tracking-label="main-CTA"]', runId, cta => {
+        if (runId === currentRunId) {
             const mbUIContainer = document.createElement('div');
             mbUIContainer.style.cssText =
                 'display: flex; flex-direction: row; flex-wrap: wrap; justify-content: center; width: 100%; gap: 4px;';
             mbUIContainer.append(...toolbarItems);
             cta.insertAdjacentElement('afterend', mbUIContainer);
+            mountedElements.push(mbUIContainer);
         }
     });
 }
 
+function processPage(): Promise<void> {
+    const runId = ++currentRunId;
+    cleanup();
+
+    const releaseUrl = window.location.href.replace(/\?.*$/, '').replace(/#.*$/, '');
+    const releaseId = releaseUrl.replace(/^https?:\/\/www\.deezer\.com\/[^/]+\/album\//i, '');
+
+    if (!releaseId || !/^\d+$/.test(releaseId)) {
+        return Promise.resolve();
+    }
+
+    return getDeezerReleaseData(releaseId, LOGGER)
+        .then(data => {
+            if (runId !== currentRunId) {
+                return;
+            }
+            if (data) {
+                const { release, isrcs } = parseDeezerRelease(releaseUrl, data);
+                insertLink(release, releaseUrl, isrcs, runId);
+            }
+        })
+        .catch((err: unknown) => {
+            LOGGER.error('Failed to parse release: ', err);
+        });
+}
+
 function init(): void {
+    MBImportStyle();
+
     // allow 1 second for Deezer SPA to initialize
     setTimeout(() => {
-        MBImportStyle();
-        const releaseUrl = window.location.href.replace(/\?.*$/, '').replace(/#.*$/, '');
-        const releaseId = releaseUrl.replace(/^https?:\/\/www\.deezer\.com\/[^/]+\/album\//i, '');
-
-        if (!releaseId || !/^\d+$/.test(releaseId)) {
-            return;
-        }
-
-        void getDeezerReleaseData(releaseId, LOGGER)
-            .then(data => {
-                if (data) {
-                    const { release, isrcs } = parseDeezerRelease(releaseUrl, data);
-                    insertLink(release, releaseUrl, isrcs);
-                }
-            })
-            .catch((err: unknown) => {
-                LOGGER.error('Failed to parse release: ', err);
-            });
+        void processPage();
     }, 1000);
+
+    subscribeToSPANavigation({
+        onNavigate: () => processPage(),
+    });
 }
 
 if (document.readyState === 'loading') {

--- a/src/userscripts/deezer_importer/meta.json
+++ b/src/userscripts/deezer_importer/meta.json
@@ -6,7 +6,7 @@
     "namespace": "https://github.com/murdos/musicbrainz-userscripts/",
     "downloadURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/deezer_importer.user.js",
     "updateURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/deezer_importer.user.js",
-    "match": ["https://www.deezer.com/*/album/*"],
+    "match": ["https://www.deezer.com/*"],
     "connect": ["api.deezer.com"],
     "grant": ["GM.xmlHttpRequest", "GM_xmlhttpRequest"],
     "icon": "https://metabrainz.org/static/img/projects/musicbrainz.svg"


### PR DESCRIPTION
_Note: Code and description were written with AI-tools_

### Description
Fixes #699. Supports client-side SPA navigation on Deezer so that the importer automatically loads on album pages and removes previously mounted buttons when navigating away, without requiring a manual page refresh.

### Changes & Rationale
- **Broaden match pattern (`meta.json`)**: Updated `@match` to `https://www.deezer.com/*` so the userscript activates across all Deezer routes. When users navigate client-side from home/search/artist pages to an album, the script is already running to handle the transition.
- **Listen for SPA navigation (`index.ts`)**: Extracted page processing into `processPage()` and subscribed to route changes using `subscribeToSPANavigation` so album detection runs on every client-side transition.
- **Teardown previously mounted UI (`cleanup()`)**: Track inserted elements in `mountedElements` and remove them upon navigation. Because Deezer reuses the same toolbar DOM node across navigations, this prevents button duplication and ensures buttons are removed when navigating to non-album pages.
- **Race condition guard (`runId`)**: Pass a monotonic `runId` to `waitForEl` and the API response handler to safely discard late DOM elements or out-of-order API responses if a user rapidly navigates between albums.

### Verification
- `pnpm type-check` (`tsgo`): 0 errors
- `pnpm lint` (`oxlint --type-aware` & `eslint .`): 0 errors, 0 warnings
- `pnpm build`: successfully compiled
- `pnpm test`: 62 tests passed
- **Live Verification**: Tested on live `deezer.com` in both desktop (`[data-testid="toolbar"]`) and mobile viewports (`[data-tracking-label="main-CTA"]`), confirming clean teardown on navigation, no button duplication, and automatic mounting across client-side album transitions.
