### PR TITLE
feat(bandlink_importer): add importer for band.link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # MusicBrainz UserScripts
 
 - [Display shortcut for relationships on MusicBrainz](#mb_relationship_shortcuts)
+- [<img src="assets/icons/typescript.svg" alt="TypeScript" width="16" height="16"> Import BandLink releases to MusicBrainz](#bandlink_importer)
 - [Import Bandcamp releases to MusicBrainz](#bandcamp_importer)
 - [<img src="assets/icons/typescript.svg" alt="TypeScript" width="16" height="16"> Import Beatport releases to MusicBrainz](#beatport_importer)
 - [Import Boomkat releases to Musicbrainz](#boomkat_importer)
@@ -37,6 +38,13 @@ Display icon shortcut for relationships of release-group, release, recording and
 
 [![Source](assets/buttons/button-source.svg)](https://github.com/murdos/musicbrainz-userscripts/blob/master/mb_relationship_shortcuts.user.js)
 [![Install](assets/buttons/button-install.svg)](https://raw.github.com/murdos/musicbrainz-userscripts/master/mb_relationship_shortcuts.user.js)
+
+## <a name="bandlink_importer"></a> <img src="assets/icons/typescript.svg" alt="TypeScript" width="16" height="16"> Import BandLink releases to MusicBrainz
+
+Import band.link smart links with Harmony and add their remaining URL relationships to MusicBrainz.
+
+[![Source](assets/buttons/button-source.svg)](https://github.com/murdos/musicbrainz-userscripts/blob/dist/bandlink_importer.user.js)
+[![Install](assets/buttons/button-install.svg)](https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/bandlink_importer.user.js)
 
 ## <a name="bandcamp_importer"></a> Import Bandcamp releases to MusicBrainz
 

--- a/src/lib/smart-link-importer/logic.ts
+++ b/src/lib/smart-link-importer/logic.ts
@@ -1,6 +1,6 @@
 export const HARMONY_SERVICE_PREFERENCE = ['spotify', 'tidal', 'deezer', 'bandcamp', 'apple', 'itunes'] as const;
 
-const TRACKING_PARAMETER_NAMES = new Set(['at', 'ct', 'ffm', 'lid', 'ref', 'ref_', 'src', 'tag']);
+const TRACKING_PARAMETER_NAMES = new Set(['at', 'ct', 'ffm', 'lid', 'ref', 'ref_', 'si', 'src', 'tag']);
 const IGNORED_SERVICES = new Set(['junodownload']);
 const PHYSICAL_MEDIA_SERVICES = new Set(['amazoncdvinyl', 'barnesnoble', 'hmvjapan', 'imusic', 'sanity', 'towerrecords']);
 const FREE_STREAMING_SERVICES = new Set(['boomplay', 'deezer', 'spotify', 'youtube']);

--- a/src/userscripts/bandlink_importer/README.md
+++ b/src/userscripts/bandlink_importer/README.md
@@ -1,0 +1,9 @@
+# BandLink importer
+
+This userscript connects a `band.link` smart-link page to its MusicBrainz release. It can start a release import through Harmony and add provider URLs that are missing from an existing release.
+
+Provider destinations are read directly from BandLink's rendered music-service links. The shared smart-link importer normalizes them, checks MusicBrainz, highlights relationships already present, and prepares any missing URL relationships.
+
+Example:
+
+`https://band.link/VXPNw`

--- a/src/userscripts/bandlink_importer/index.ts
+++ b/src/userscripts/bandlink_importer/index.ts
@@ -1,0 +1,32 @@
+import { runSmartLinkImporter, type ServiceElement } from '~/lib/smart-link-importer';
+import { isIgnoredService, isPhysicalMediaLink, normalizeServiceName } from '~/lib/smart-link-importer/logic';
+
+function collectServiceElements(): ServiceElement[] {
+    const counters = new Map<string, number>();
+    const elements: ServiceElement[] = [];
+    for (const element of document.querySelectorAll<HTMLAnchorElement>('.mod-music-services a.el-link[href]')) {
+        const label = element.querySelector<HTMLElement>('.el-link__service-text')?.textContent.trim() || '';
+        const service = normalizeServiceName(label);
+        const action = element.querySelector<HTMLElement>('.el-link__action')?.textContent.trim() || '';
+        if (!service || isIgnoredService(service) || isPhysicalMediaLink(service, action) || !element.href) continue;
+
+        const count = (counters.get(service) ?? 0) + 1;
+        counters.set(service, count);
+        elements.push({
+            cacheKey: count === 1 ? service : `${service}:${count}`,
+            element,
+            service,
+            label,
+            action,
+            sourceUrl: element.href,
+        });
+    }
+    return elements;
+}
+
+void runSmartLinkImporter({
+    id: 'bandlink',
+    siteName: 'BandLink',
+    collectServiceElements,
+    resolveDestination: element => element.sourceUrl,
+});

--- a/src/userscripts/bandlink_importer/meta.json
+++ b/src/userscripts/bandlink_importer/meta.json
@@ -1,0 +1,13 @@
+{
+    "name": "Import BandLink releases to MusicBrainz",
+    "description": "Import band.link smart links with Harmony and add their remaining URL relationships to MusicBrainz.",
+    "version": "2026.09.08.1",
+    "author": "Raman Sinclair",
+    "namespace": "https://github.com/murdos/musicbrainz-userscripts/",
+    "downloadURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/bandlink_importer.user.js",
+    "updateURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/bandlink_importer.user.js",
+    "match": ["https://band.link/*", "https://*.band.link/*"],
+    "grant": ["GM.getValue", "GM.setValue", "GM_getValue", "GM_setValue"],
+    "runAt": "document-idle",
+    "icon": "https://metabrainz.org/static/img/projects/musicbrainz.svg"
+}

--- a/tests/ffm_importer/logic.test.ts
+++ b/tests/ffm_importer/logic.test.ts
@@ -52,6 +52,9 @@ describe('FFM importer logic', () => {
                 'qobuz',
             ),
         ).toBe('https://www.qobuz.com/us-en/album/salvaging-the-future-dean-de-benedictis/ki3mxj3oly9vd');
+        expect(normalizeServiceUrl('https://example.com/release?si=share-id&utm_source=clipboard', 'other')).toBe(
+            'https://example.com/release',
+        );
     });
 
     it('matches regional Apple URLs by album ID', () => {


### PR DESCRIPTION
- adds a BandLink smartlink importer using the shared MusicBrainz importer infrastructure. Collects rendered provider destinations, supports Harmony imports and missing URL relationships, and normalizes tracking parameters.
- test URL: https://band.link/VXPNw