### PR TITLE
fix: bump individual smartlink importers again

### DIFF
--- a/src/userscripts/albumlink_importer/meta.json
+++ b/src/userscripts/albumlink_importer/meta.json
@@ -1,7 +1,7 @@
 {
     "name": "Import album.link releases to MusicBrainz",
     "description": "Deprecated: install the unified Smartlink importer, then remove this script.",
-    "version": "2026.09.12.1",
+    "version": "2026.09.13.1",
     "author": "Raman Sinclair",
     "namespace": "https://github.com/murdos/musicbrainz-userscripts/",
     "downloadURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/albumlink_importer.user.js",

--- a/src/userscripts/bandlink_importer/meta.json
+++ b/src/userscripts/bandlink_importer/meta.json
@@ -1,7 +1,7 @@
 {
     "name": "Import BandLink releases to MusicBrainz",
     "description": "Deprecated: install the unified Smartlink importer, then remove this script.",
-    "version": "2026.09.12.1",
+    "version": "2026.09.13.1",
     "author": "Raman Sinclair",
     "namespace": "https://github.com/murdos/musicbrainz-userscripts/",
     "downloadURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/bandlink_importer.user.js",

--- a/src/userscripts/bfan_importer/meta.json
+++ b/src/userscripts/bfan_importer/meta.json
@@ -1,7 +1,7 @@
 {
     "name": "Import bfan.link releases to MusicBrainz",
     "description": "Deprecated: install the unified Smartlink importer, then remove this script.",
-    "version": "2026.09.12.1",
+    "version": "2026.09.13.1",
     "author": "Raman Sinclair",
     "namespace": "https://github.com/murdos/musicbrainz-userscripts/",
     "downloadURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/bfan_importer.user.js",

--- a/src/userscripts/fanlink_importer/meta.json
+++ b/src/userscripts/fanlink_importer/meta.json
@@ -1,7 +1,7 @@
 {
     "name": "Import Fanlink releases to MusicBrainz",
     "description": "Deprecated: install the unified Smartlink importer, then remove this script.",
-    "version": "2026.09.12.1",
+    "version": "2026.09.13.1",
     "author": "Raman Sinclair",
     "namespace": "https://github.com/murdos/musicbrainz-userscripts/",
     "downloadURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/fanlink_importer.user.js",

--- a/src/userscripts/ffm_importer/meta.json
+++ b/src/userscripts/ffm_importer/meta.json
@@ -1,7 +1,7 @@
 {
     "name": "Import FFM releases to MusicBrainz",
     "description": "Deprecated: install the unified Smartlink importer, then remove this script.",
-    "version": "2026.09.12.1",
+    "version": "2026.09.13.1",
     "author": "Raman Sinclair",
     "namespace": "https://github.com/murdos/musicbrainz-userscripts/",
     "downloadURL": "https://raw.githubusercontent.com/murdos/musicbrainz-userscripts/dist/ffm_importer.user.js",


### PR DESCRIPTION
- timezone bug (🤦🏻 I'm a couple of hours ahead of Github CIs timezone, so I bumped it to 2026.09.13 and then github ci bumped it down to 2026.09.12).